### PR TITLE
app: let Ctrl-C interrupt listing a directory

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<()> 
             if key.kind == event::KeyEventKind::Release {
                 continue;
             }
-            app.handle_key(key.code);
+            app.handle_key(key);
         }
     }
     Ok(())

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -1,4 +1,4 @@
-use crossterm::event::KeyCode;
+use crossterm::event::{KeyCode, KeyEvent};
 
 use std::path::PathBuf;
 
@@ -28,9 +28,9 @@ pub const HELP: &[[&str; 2]] = &[
 ];
 
 impl App {
-    pub fn handle_key(&mut self, key: KeyCode) {
+    pub fn handle_key(&mut self, key: KeyEvent) {
         if self.popup.is_some() {
-            match key {
+            match key.code {
                 KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') | KeyCode::Char('?') => {
                     self.popup(None, None, None);
                 }
@@ -69,7 +69,7 @@ impl App {
             return;
         }
 
-        match key {
+        match key.code {
             KeyCode::Enter => {
                 if let Some(selected) = self.dir_listing.selected() {
                     let entry = self.dir_listing.get(selected);


### PR DESCRIPTION
Changing the cwd into a directory with a huge number of entries can cause the TUI to hang. To let the user bail out, we now listen for `Ctrl-C` while listing directories.

The implementation is hacky! We're egregiously mixing UI and filesystem concerns now. The "right" fix would be to use an async runtime like tokio or smol, preferrably with smol's [async-fs](https://github.com/smol-rs/async-fs). This would let us listen for async key presses while listing directory entries.

Helps with #7.
