### PR TITLE
v1.0 dev

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,5 +34,5 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --verbose
-    # - name: Run tests
-    #   run: cargo test --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,5 +34,7 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --verbose
+    # The tests in tests/ceph.rs skip themselves when there is no CephFS mount,
+    # which is always the case here.
     - name: Run tests
       run: cargo test --verbose

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,8 +248,13 @@ Other things worth knowing before editing:
   0.29/0.28), and the mechanism is an OSC 11 query, which needs raw-mode care, a timeout, and tmux passthrough.
   `terminal-colorsaurus` or `terminal-light` would be the crates if it is ever wanted -- but inheriting the
   terminal's colors makes detection unnecessary in the first place.
-- `POPUP_TEXT_HEIGHT` in [ui.rs](src/ui.rs) is a fixed constant that popup scroll clamping and scrollbar state
-  depend on; the popup is not sized to the terminal.
+- The popup is sized to the terminal by `popup_text_height` in [ui.rs](src/ui.rs) — as many rows of its text as
+  the frame has room for — so `Popup::view_height` is state the *renderer* writes, like `App::hscroll`, and
+  scroll clamping and the scrollbar both read it. Two consequences: `set_view_height` re-clamps the scroll,
+  since a resize can leave it past the new end; and it is zero until the first frame, so anything reading
+  `max_scroll` before one is drawn (a test that presses a key without rendering) sees the untruncated text. The
+  scrollbar is drawn only when `max_scroll() > 0`, which is why the block's `bottom_right` corner has to be a
+  connector — the scrollbar's `▼` used to cover it.
 - The gauge in `gauge()` draws the percentage text *inside* the bar with inverted colors on the overlapping
   region, using ⅛-block characters for sub-cell precision.
 - `format::Numbers` is the single switch between unit-scaled and exact rendering, and every size or count in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,16 @@ Any new accessor that maps a selection index to a `DirEntry` must go through `ge
 
 Other things worth knowing before editing:
 
-- `rentries` has 1 subtracted because Ceph counts the directory itself.
+- A sort field has three touch points: the `SortField` variant, the key arm in [navigation.rs](src/navigation.rs)
+  with its `HELP` row, and the flag in `SortFlags` in [main.rs](src/main.rs). Its starting direction lives in one
+  place only, `SortField::default_mode()`, which both the key and the flag go through — that is what keeps `-s`
+  and pressing `s` in agreement, so don't reintroduce a literal `SortMode::Reversed(...)` at a call site. `-r`
+  applies `as_reversed()` on top and so needs nothing per field. Uppercase short flags were considered for
+  reversal and rejected: `U` and `T` are already the interface's sort keys for owner and time, so `-T` would have
+  meant the opposite of pressing `T`.
+- `rentries` has 1 subtracted because Ceph counts the directory itself. Specifically it is `rsubdirs` that
+  includes the directory, since `rentries == rfiles + rsubdirs`; the non-recursive `ceph.dir.entries` has no such
+  self-count.
 - Off-Ceph, directory sizes are deliberately discarded (`e.size = None`) and `total_size` forced to 0, since
   non-Ceph dir sizes are meaningless here; a warning message is shown. The app is expected to run on non-Ceph
   paths, so keep that path working.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,13 @@ Other things worth knowing before editing:
   applies `as_reversed()` on top and so needs nothing per field. Uppercase short flags were considered for
   reversal and rejected: `U` and `T` are already the interface's sort keys for owner and time, so `-T` would have
   meant the opposite of pressing `T`.
+- Symlinks: `DirEntry::name` carries the directory `/` but *not* the symlink `@`, and the difference is
+  deliberate. `/` cannot occur in a filename, so it is unambiguous in the parseable stream, which documents it.
+  `@` can occur, so marking names with it there would be indistinguishable from a real character;
+  `display_name()` applies it and only the TUI and the human flat format call that. The rest of #12 is untouched:
+  the size shown is the link's own (the length of the path it holds), a directory symlink sorts among the files,
+  and `Enter` on one does nothing, since `try_cd` canonicalizes and going back through a symlink would need that
+  reworked.
 - `rentries` has 1 subtracted because Ceph counts the directory itself. Specifically it is `rsubdirs` that
   includes the directory, since `rentries == rfiles + rsubdirs`; the non-recursive `ceph.dir.entries` has no such
   self-count.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ Layering, roughly bottom-up:
   output modes. Pure functions, so this is where formatting tests live.
 - [navigation.rs](src/navigation.rs) — `App::handle_key`, plus the `HELP` table that is both the key mapping's
   documentation and the source of the `?` popup text. Add a keybinding *and* its `HELP` row together.
-- [ui.rs](src/ui.rs) — pure rendering from `&App`; no state changes except ratatui's own `ListState`.
+- [ui.rs](src/ui.rs) — rendering from `&mut App`. The only state it writes is ratatui's `ListState` and the
+  clamp of `App::hscroll`, both of which depend on the area being drawn into.
 - [flat.rs](src/flat.rs) — the non-interactive renderer, which takes a `DirListing` and a `Write`.
 - [popup.rs](src/popup.rs) — scrollable modal used only for help so far.
 
@@ -116,6 +117,11 @@ Other things worth knowing before editing:
   with the right-aligned help hint, so it costs no vertical space. `SortField::label()` is the naming authority
   for both it and the CLI flags. The golden frame in [ui.rs](src/ui.rs) includes this line, so a change to the
   status wording means regenerating it.
+- Horizontal scrolling is ours, not ratatui's: `List` has no horizontal offset (only `Paragraph` does, via
+  `scroll((y, x))`). `render_list` draws the block itself, renders the rows into a `Buffer` as wide as they need,
+  and copies a window of it into the block's inner area. That scrolls every column identically and keeps the
+  border and its titles fixed, at the cost of one buffer per frame. The window is why `hscroll` is clamped during
+  rendering rather than in the key handler.
 - `POPUP_TEXT_HEIGHT` in [ui.rs](src/ui.rs) is a fixed constant that popup scroll clamping and scrollbar state
   depend on; the popup is not sized to the terminal.
 - The gauge in `gauge()` draws the percentage text *inside* the bar with inverted colors on the overlapping

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,10 @@ Other things worth knowing before editing:
   falling back to index. On the first arrival in a directory there is nothing to restore, so
   `select_first_entry()` skips `..` and lands on the first real entry; `select_first()` is the literal top of the
   list and stays bound to Home/`g`. Refresh and Backspace go through the remembered path, so they don't jump.
+- The top border puts the path on the left and the totals on the right, and the path is truncated from its
+  *start* by `truncate_start` so the deepest components stay visible while navigating. The path's room is
+  whatever the totals leave, computed from `area.width` rather than left to ratatui, which would otherwise let
+  the two titles collide.
 - The bottom border carries a status area (sort field, direction, and `dirs first` when on) sharing the border
   with the right-aligned help hint, so it costs no vertical space. `SortField::label()` is the naming authority
   for both it and the CLI flags. The golden frame in [ui.rs](src/ui.rs) includes this line, so a change to the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,8 @@ Any new accessor that maps a selection index to a `DirEntry` must go through `ge
 Other things worth knowing before editing:
 
 - A sort field has three touch points: the `SortField` variant, the key arm in [navigation.rs](src/navigation.rs)
-  with its `HELP` row, and the flag in `SortFlags` in [main.rs](src/main.rs). Its starting direction lives in one
+  with its `HELP` row, and the flag in `SortFlags` in [main.rs](src/main.rs). `default_mode()` and `label()` are
+  exhaustive matches on the enum, so the compiler catches those two. Its starting direction lives in one
   place only, `SortField::default_mode()`, which both the key and the flag go through — that is what keeps `-s`
   and pressing `s` in agreement, so don't reintroduce a literal `SortMode::Reversed(...)` at a call site. `-r`
   applies `as_reversed()` on top and so needs nothing per field. Uppercase short flags were considered for
@@ -111,6 +112,10 @@ Other things worth knowing before editing:
   falling back to index. On the first arrival in a directory there is nothing to restore, so
   `select_first_entry()` skips `..` and lands on the first real entry; `select_first()` is the literal top of the
   list and stays bound to Home/`g`. Refresh and Backspace go through the remembered path, so they don't jump.
+- The bottom border carries a status area (sort field, direction, and `dirs first` when on) sharing the border
+  with the right-aligned help hint, so it costs no vertical space. `SortField::label()` is the naming authority
+  for both it and the CLI flags. The golden frame in [ui.rs](src/ui.rs) includes this line, so a change to the
+  status wording means regenerating it.
 - `POPUP_TEXT_HEIGHT` in [ui.rs](src/ui.rs) is a fixed constant that popup scroll clamping and scrollbar state
   depend on; the popup is not sized to the terminal.
 - The gauge in `gauge()` draws the percentage text *inside* the bar with inverted colors on the overlapping

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,12 @@ cargo test -- --nocapture        # SKIP notices from tests/ceph.rs, syscall tabl
 CEPHDU_TEST_DIR=<ceph path> cargo test --test ceph
 ```
 
-Compile-time configuration: `CEPHDU_DEFAULT_DIR=/mnt/ceph/users/\$USER cargo build --release` bakes in a
-fallback directory (read via `option_env!` in [main.rs](src/main.rs)); the literal `$USER` is substituted at
-runtime. Release binaries are built for gnu/musl × x86_64/aarch64 by
+Default-directory configuration: `CEPHDU_DEFAULT_DIR=/mnt/ceph/users/\$USER cargo build --release` bakes in a
+fallback directory (read via `option_env!` in [main.rs](src/main.rs)); the same-named environment variable
+overrides it at runtime (set closer to the machine — it's how a site modulefile picks the right mount per
+cluster, issue #19), and set-but-empty disables both. The literal `$USER` is substituted at runtime in either.
+A default only applies when no path is given and the cwd is not itself on Ceph (`default_dir`); the flat_cli
+tests scrub the variable so a shell that sets it can't perturb them. Release binaries are built for gnu/musl × x86_64/aarch64 by
 [.github/workflows/release.yml](.github/workflows/release.yml) on GitHub Release publish.
 
 Rust edition 2024; the code uses let-chains, so a recent toolchain is required.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,10 @@ Layering, roughly bottom-up:
 - [fs.rs](src/fs.rs) — the only `unsafe`/libc code: `lgetxattr` for the three r-attrs, `statfs` for
   filesystem-type detection, `getpwuid_r` for uid→name (memoized in a global `NAME_CACHE`). Returns `Option`
   everywhere; a missing xattr is normal, not an error.
-- [app.rs](src/app.rs) — all state. `App` holds the cwd and one `DirListing`; `DirListing` holds `Vec<DirEntry>`
-  plus a ratatui `ListState`, sort mode, and aggregate `ListingStats`. `DirEntry::from` is where one stat +
-  three xattr calls happen per entry.
+- [app.rs](src/app.rs) — all state. `App` holds the cwd, one `DirListing`, and the machinery for the listing in
+  flight (`pending`, a generation counter, the worker channel's sender); `DirListing` holds `Vec<DirEntry>`
+  plus a ratatui `ListState`, sort mode, and aggregate `ListingStats`. `DirEntry::from` is where the per-entry
+  stat and xattr calls happen.
 - [format.rs](src/format.rs) — the base-1000 size/count units and the `ls -l`-style time format, shared by both
   output modes. Pure functions, so this is where formatting tests live.
 - [navigation.rs](src/navigation.rs) — `App::handle_key`, plus the `HELP` table that is both the key mapping's
@@ -48,10 +49,34 @@ Layering, roughly bottom-up:
 - [flat.rs](src/flat.rs) — the non-interactive renderer, which takes a `DirListing` and a `Write`.
 - [popup.rs](src/popup.rs) — scrollable modal used only for help so far.
 
-Control flow for the TUI is a blocking loop in `run_app`: draw, block on `event::read()`, dispatch to
-`handle_key`. There is no tick, no async runtime, and no redraw except after a key press. `cd` re-reads the whole
-directory synchronously, so a large directory blocks; `ls()` works around this by polling for Ctrl-C
-mid-iteration, which [app.rs](src/app.rs) itself flags as the wrong fix.
+Control flow for the TUI is a `tokio::select!` loop in `run_app` (issue #18): draw, then wait on whichever comes
+first of a key event (crossterm's `EventStream`), a listing worker's answer, or — only while a read is in
+flight — a 100ms tick that keeps the progress notice current. There is no free-running tick. The runtime is
+current-thread and multiplexes wake-ups only: every filesystem call is a blocking syscall, so listings run on
+plain `std::thread`s that `App::start_listing` spawns, not on runtime tasks — which is also why quitting never
+waits on a worker stuck in a syscall (nothing joins it; process exit reaps it) and why `App` works without a
+runtime, unit tests included. The moving parts and their traps:
+
+- Cancellation is cooperative and stays so under any runtime: a thread mid-`lgetxattr` cannot be aborted, so
+  `ls()` checks an atomic flag between entries (a load, not a syscall — [tests/syscalls.rs](tests/syscalls.rs)
+  still holds) and returns `ErrorKind::Interrupted`. The flag lives in `ListingWatch`, shared worker/interface,
+  which also carries the entries-so-far counter the progress notice reads.
+- A worker's answer is applied only if its generation matches the one `pending` — superseding (a `cd` during a
+  `cd`) and cancelling both orphan the old answer, which may still arrive and must be dropped, not applied.
+  Anything that changes what a listing shows goes through `start_listing`/`on_listing_msg`; there is no
+  synchronous cd left.
+- Cancel semantics: Esc and Ctrl-C stop the read and keep the directory on screen (the old listing was never
+  replaced); while idle they do nothing. Only `q` quits, deliberately: a cancel key that doubled as quit would
+  make an extra press — or one landing just after the read finishes — exit unintended, which is why Esc lost its
+  quit binding when it gained cancel. The Ctrl-C key arm must stay *above* the `'c'` sort arm with a `CONTROL`
+  guard, or Ctrl-C sorts by count again.
+- Startup goes through the same path: `App::new` reads nothing, `run_app` dispatches the first listing, and the
+  old fall-back-to-`.` logic is the `OnError::Fallback` arm. `Pending::preserve_message` exists because that
+  fallback sets a warning that the fallback listing's arrival must not clear.
+- In unit tests, every call that can dispatch a read (`cd`, the toggles, the sorts) needs `App::pump` after it,
+  which drains the channel the way the event loop would — otherwise the answer sits unapplied and the test
+  asserts against the stale listing. The ui.rs tests do the opposite: they drop the receiver and must never
+  dispatch, which holds because their synthetic listing already has owners and times.
 
 ### Output modes
 
@@ -240,9 +265,8 @@ dependency, deliberately — cargo already provides both paths.
   one `statx` per file, two `lgetxattr` per directory and no stat for a directory at all, and nothing else
   scales — that last part is the
   assertion worth keeping, since an accidental per-entry syscall is what makes a large directory slow. Skips
-  without strace or ptrace permission. It cannot see the Ctrl-C poll in `ls()`, which only costs a syscall when
-  crossterm's event source initialises, and that needs a controlling terminal: under a test runner /dev/tty
-  fails with ENXIO, so the interface may pay one more syscall per entry than the harness reports.
+  without strace or ptrace permission. The numbers hold for the interface too: the cancellation check between
+  entries is an atomic load, not a syscall.
 - [tests/ceph.rs](tests/ceph.rs) — the only coverage of the xattrs themselves, and the only tests that can't run
   in CI. They skip (not fail) with a `SKIP` notice when no CephFS is available, so `cargo test` is green
   everywhere. The MDS updates recursive stats asynchronously, so assertions poll until the tree settles;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,17 +143,31 @@ Other things worth knowing before editing:
   `@` can occur, so marking names with it there would be indistinguishable from a real character;
   `display_name()` applies it and only the TUI and the human flat format call that. The rest of #12 is untouched:
   the size shown is the link's own (the length of the path it holds), a directory symlink sorts among the files,
-  and `Enter` on one does nothing, since `try_cd` canonicalizes and going back through a symlink would need that
-  reworked.
+  and `Enter` on one does nothing, since the listing worker canonicalizes and going back through a symlink
+  would need that reworked.
 - `Options` is what a read needs to know — sort mode, `dirs_first`, `owners` — and travels as one value rather
   than a run of booleans, which is what `DirListing::from` and `App::new` take.
 - `DirListing::options.owners` records what that listing *was read with*, not what the next read should do. The
   distinction matters: `toggle_owner` re-reads only when the listing never had owners, so hiding the column and
-  showing it again is free however many times, while `try_cd` builds the next read's options from
+  showing it again is free however many times, while `start_listing` builds a *new* directory's options from
   `App::needs()` so leaving with a column hidden doesn't make the next directory pay. Conflating the two made the
   third press of `u` re-read; there are tests with sentinel values for both fields. `App::needs()` is also where
   *ordering* by a field counts as needing it: sorting by owner or by time without reading them silently sorted
   by nothing, which is a bug worth not reintroducing.
+- Which is why acquiring a column for the listing on screen is not a re-read at all: `fetch_if_needed`
+  dispatches `start_columns`, which fetches only what is missing (`needs \ has`) and merges it in
+  (`DirListing::absorb`) — no readdir, nothing already read touched, so every column stays cached until the
+  directory is left or refreshed. It fetches per kind: a directory's time is one xattr and its owner one stat,
+  while a file's time and raw uid/gid were kept from the stat the listing already did (`DirEntry::{uid,gid}`),
+  so a file's owner is only the name lookup. The first version instead re-read the whole directory with options
+  built from what was currently shown — reading the time while the owner column was hidden dropped the owner, so
+  `u` then `t` then `u` paid for the owner twice, though repeating either key alone looked perfectly cached.
+  `absorb` re-sorts unconditionally, since the point of fetching a column is often to order by it.
+- `fetch_if_needed` defers while any read is in flight rather than superseding it: whatever lands re-checks on
+  arrival, so it converges instead of cancelling a `cd` to fetch columns for a directory about to be replaced.
+  The other half of that convergence is that an arriving listing conforms to the *screen's* sort and grouping,
+  not dispatch-time's: change the sort during a slow `cd` and the arrival re-sorts (by absent values if it must —
+  the arrival's `fetch_if_needed` then fetches them and `absorb` re-sorts with data).
 - `-l` implies `--flat` and conflicts with `--tui`: a flat listing is the one with no way to ask later, while
   the interface has `u` and `t`, which read on demand. That is why it selects a mode rather than being ignored
   in one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ runtime, unit tests included. The moving parts and their traps:
   taken from a full readdir pass first: stats lean on readdir's prefetch staying cached, and on a huge
   directory a drain-then-stat ordering would let it expire.
 - The hidden `-j` flag (`Options::jobs`) fans the per-entry syscalls out over scoped worker threads,
-  `read_batched`. It is deliberately undocumented — it changes speed, never output, and may change or vanish —
+  `read_streamed`. It is deliberately undocumented — it changes speed, never output, and may change or vanish —
   so keep it out of the README and the help text; tests pin both the hiding and the output equality. The feed
   channel is bounded for the same prefetch reason as above, but streams rather than batching, because the
   readdir is itself a substantial serial cost (readdirplus, ~750µs/entry on Ceph) and overlapping it with the
@@ -276,8 +276,9 @@ dependency, deliberately — cargo already provides both paths.
   starting a process cancels and the numbers don't move with the libc or kernel underneath. Today a listing costs
   one `statx` per file, two `lgetxattr` per directory and no stat for a directory at all, and nothing else
   scales — that last part is the
-  assertion worth keeping, since an accidental per-entry syscall is what makes a large directory slow. Skips
-  without strace or ptrace permission. The numbers hold for the interface too: the cancellation check between
+  assertion worth keeping, since an accidental per-entry syscall is what makes a large directory slow.
+  `getdents64` is exempt from it, since a batched call grows by whole buffers as entries are added and
+  `readdir_is_batched` is what holds it to that. Skips without strace or ptrace permission. The numbers hold for the interface too: the cancellation check between
   entries is an atomic load, not a syscall.
 - [tests/ceph.rs](tests/ceph.rs) — the only coverage of the xattrs themselves, and the only tests that can't run
   in CI. They skip (not fail) with a `SKIP` notice when no CephFS is available, so `cargo test` is green

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,11 @@ The listing has two independent index transformations between storage order and 
 2. `..` is a synthetic entry in the separate `dotdot` field, displayed at index 0 and absent from `entries`.
    `len()`, `get()`, and anything consuming `selected()` must account for the +1 offset.
 
+Both interact with `dirs_first`, which is why its grouping key in `sort()` is inverted under a reversed mode:
+storage is ascending, so directories have to be stored *last* to display *first*. Two consequences that are easy
+to get wrong — a change in direction alone now requires a re-sort, so `sort()` can only short-circuit while
+`dirs_first` is off, and any new grouping must go through the same key rather than being applied at display time.
+
 Any new accessor that maps a selection index to a `DirEntry` must go through `get()` rather than indexing
 `entries`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,8 @@ follows from that.
 
 Layering, roughly bottom-up:
 
-- [fs.rs](src/fs.rs) — the only `unsafe`/libc code: `lgetxattr` for the three r-attrs, `statfs` for
+- [fs.rs](src/fs.rs) — the only `unsafe`/libc code: `lgetxattr` for the three r-attrs and the non-recursive
+  entry count, `statfs` for
   filesystem-type detection, `getpwuid_r` for uid→name (memoized in a global `NAME_CACHE`). Returns `Option`
   everywhere; a missing xattr is normal, not an error.
 - [app.rs](src/app.rs) — all state. `App` holds the cwd, one `DirListing`, and the machinery for the listing in
@@ -60,7 +61,10 @@ runtime, unit tests included. The moving parts and their traps:
 - Cancellation is cooperative and stays so under any runtime: a thread mid-`lgetxattr` cannot be aborted, so
   `ls()` checks an atomic flag between entries (a load, not a syscall — [tests/syscalls.rs](tests/syscalls.rs)
   still holds) and returns `ErrorKind::Interrupted`. The flag lives in `ListingWatch`, shared worker/interface,
-  which also carries the entries-so-far counter the progress notice reads.
+  which also carries what the progress notice reads: the entries-so-far counter and, on Ceph, the expected
+  total, priced upfront from `ceph.dir.entries` — one more constant xattr read per listing, deliberately not
+  taken from a full readdir pass first: stats lean on readdir's prefetch staying cached, and on a huge
+  directory a drain-then-stat ordering would let it expire.
 - A worker's answer is applied only if its generation matches the one `pending` — superseding (a `cd` during a
   `cd`) and cancelling both orphan the old answer, which may still arrive and must be dropped, not applied.
   Anything that changes what a listing shows goes through `start_listing`/`on_listing_msg`; there is no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,13 @@ Other things worth knowing before editing:
 - `POPUP_TEXT_HEIGHT` in [ui.rs](src/ui.rs) is a fixed constant that popup scroll clamping and scrollbar state
   depend on; the popup is not sized to the terminal.
 - The gauge in `gauge()` draws the percentage text *inside* the bar with inverted colors on the overlapping
-  region, using ⅛-block characters for sub-cell precision. Sizes/counts use base-1000 units.
+  region, using ⅛-block characters for sub-cell precision.
+- `format::Numbers` is the single switch between unit-scaled and exact rendering, and every size or count in
+  either output mode goes through it. Row widths are measured per frame in `App::columns()` rather than
+  hardcoded, because exact values are wider than any unit form; `SIZE_WIDTH`/`RENTRIES_WIDTH` are the minimums
+  the unit forms fit in, which is what keeps the golden frame stable when the mode is off.
+- Frame rows contain three-byte box and block characters, so a test that locates a column with `str::rfind` gets
+  a byte offset, not a screen column. Convert with `line[..byte].chars().count()`.
 - Times shown are `rctime` for directories and `ctime` for files — deliberately ctime, not mtime; see the
   `after_help` text in [main.rs](src/main.rs).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,34 @@ Other things worth knowing before editing:
   and copies a window of it into the block's inner area. That scrolls every column identically and keeps the
   border and its titles fixed, at the cost of one buffer per frame. The window is why `hscroll` is clamped during
   rendering rather than in the key handler.
+- The interface sets almost no colors: backgrounds and text are left to the terminal, so it suits a light
+  terminal as well as a dark one. `ERROR_STYLE` and `WARNING_STYLE` in [ui.rs](src/ui.rs) are the only named
+  colors, and they are named for their meaning. Never reach for `Color::Rgb`/`Indexed` — those don't follow the
+  user's terminal theme, and `the_interface_names_no_absolute_colors` renders a frame and fails if any appear.
+  A user-selectable palette was tried and removed; see the history if it comes back up.
+- The cursor row is shaded with a named background pair (`SELECTED_STYLE`: grey behind white) plus the `> `
+  marker, and deliberately *not* bold — bold brightens the text on top of the color change, so the row reads as
+  lightening rather than as marked. Grey rather than blue because `Color::Blue` is ANSI 4, already the darkest blue in
+  the 16, so on a theme that renders it brightly there is nothing left to raise the contrast with; `DarkGray` is
+  the only named color darker than it that won't merge into a dark terminal's own background. Going darker still means leaving
+  the 16 for `Indexed`/`Rgb`, defensible only here, where both halves of the pair are named and so carry their
+  own contrast.
+  The white foreground is for light terminals: with an inherited foreground the text would be dark on a dark
+  band there. Inheriting it instead is the one-line change that keeps the text from shifting color at all, at
+  that cost.
+  Two alternatives were tried and rejected. Reverse video adapts to any terminal for free, but it inverts the
+  gauges: a `█` reversed is drawn in the background color while a reversed empty cell paints the foreground
+  across its full width, so a bar shows the wrong value. Marker-and-bold alone, with no background, reads as too
+  subtle.
+- The gauges opt out of the cursor row's styling: `bar` in `gauge()` pins the foreground to `Color::Reset` and
+  removes `BOLD`, so a bar is the same color on every row and the column reads as one chart. Only the background
+  behind it comes from the row, which is what keeps the shading continuous across the row. The percentage over
+  the bar reverses the terminal's own pair rather than the row's, since reversing the cursor row's blue would put
+  blue text on the bar — fine on a dark terminal, barely legible on a light one.
+- Terminal light/dark detection is deliberately absent: neither ratatui nor crossterm can do it (checked in
+  0.29/0.28), and the mechanism is an OSC 11 query, which needs raw-mode care, a timeout, and tmux passthrough.
+  `terminal-colorsaurus` or `terminal-light` would be the crates if it is ever wanted -- but inheriting the
+  terminal's colors makes detection unnecessary in the first place.
 - `POPUP_TEXT_HEIGHT` in [ui.rs](src/ui.rs) is a fixed constant that popup scroll clamping and scrollbar state
   depend on; the popup is not sized to the terminal.
 - The gauge in `gauge()` draws the percentage text *inside* the bar with inverted colors on the overlapping

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,134 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```console
+cargo run [-- PATH]              # build and launch the TUI
+cargo run -- --flat [PATH]       # flat text mode, which is scriptable and testable
+cargo build --release
+cargo clippy --all-targets       # pre-commit runs fmt + cargo-check + clippy
+pre-commit run --all-files
+
+cargo test
+cargo test --bin cephdu          # unit tests only (fast, no filesystem)
+cargo test <substring>           # one test, e.g. cargo test renders_the_listing
+cargo test -- --nocapture        # needed to see the SKIP notices from tests/ceph.rs
+CEPHDU_TEST_DIR=<ceph path> cargo test --test ceph
+```
+
+Compile-time configuration: `CEPHDU_DEFAULT_DIR=/mnt/ceph/users/\$USER cargo build --release` bakes in a
+fallback directory (read via `option_env!` in [main.rs](src/main.rs)); the literal `$USER` is substituted at
+runtime. Release binaries are built for gnu/musl × x86_64/aarch64 by
+[.github/workflows/release.yml](.github/workflows/release.yml) on GitHub Release publish.
+
+Rust edition 2024; the code uses let-chains, so a recent toolchain is required.
+
+## Architecture
+
+The premise: on CephFS, recursive directory size, file count, and mtime are available as extended attributes
+(`ceph.dir.rbytes`, `ceph.dir.rentries`, `ceph.dir.rctime`), so disk usage needs no tree walk. Everything else
+follows from that.
+
+Layering, roughly bottom-up:
+
+- [fs.rs](src/fs.rs) — the only `unsafe`/libc code: `lgetxattr` for the three r-attrs, `statfs` for
+  filesystem-type detection, `getpwuid_r` for uid→name (memoized in a global `NAME_CACHE`). Returns `Option`
+  everywhere; a missing xattr is normal, not an error.
+- [app.rs](src/app.rs) — all state. `App` holds the cwd and one `DirListing`; `DirListing` holds `Vec<DirEntry>`
+  plus a ratatui `ListState`, sort mode, and aggregate `ListingStats`. `DirEntry::from` is where one stat +
+  three xattr calls happen per entry.
+- [format.rs](src/format.rs) — the base-1000 size/count units and the `ls -l`-style time format, shared by both
+  output modes. Pure functions, so this is where formatting tests live.
+- [navigation.rs](src/navigation.rs) — `App::handle_key`, plus the `HELP` table that is both the key mapping's
+  documentation and the source of the `?` popup text. Add a keybinding *and* its `HELP` row together.
+- [ui.rs](src/ui.rs) — pure rendering from `&App`; no state changes except ratatui's own `ListState`.
+- [flat.rs](src/flat.rs) — the non-interactive renderer, which takes a `DirListing` and a `Write`.
+- [popup.rs](src/popup.rs) — scrollable modal used only for help so far.
+
+Control flow for the TUI is a blocking loop in `run_app`: draw, block on `event::read()`, dispatch to
+`handle_key`. There is no tick, no async runtime, and no redraw except after a key press. `cd` re-reads the whole
+directory synchronously, so a large directory blocks; `ls()` works around this by polling for Ctrl-C
+mid-iteration, which [app.rs](src/app.rs) itself flags as the wrong fix.
+
+### Output modes
+
+`main` picks the mode before building an `App`: flat mode goes straight from `DirListing::from` to
+`flat::write_listing`, never constructing one. The TUI draws to stdout, so it can't work when stdout is
+redirected — hence flat mode is implied when stdout isn't a terminal, with `--tui` as the escape hatch for
+pty-wrapping tools. Two properties of flat mode are deliberate and worth preserving:
+
+- `--flat` (`-f`) selects the format with units and `--parseable` (`-p`) the raw one. Neither varies with the
+  terminal, so parsers see the same bytes however the tool is invoked. This is also why flat mode has no column-visibility flags: the TUI's `u`/`t` toggles exist
+  because terminal width is scarce, a pipe has no such limit, and a fixed column set keeps field offsets stable.
+  It also leaves the remaining `-<key>` short flags free for the startup sort flags in issue #11.
+- An implied flat listing (no flag, stdout not a terminal) is parseable rather than human, on the grounds that a
+  pipe is more often read by a program.
+- Flat mode does *not* fall back to the current directory when the path fails to open, unlike the TUI. A script
+  needs the failure.
+
+Adding a column to flat mode is a breaking change for anything parsing it; append rather than insert.
+
+### Traps
+
+The listing has two independent index transformations between storage order and display order, and both live in
+`DirListing`:
+
+1. `entries` is always sorted **ascending**. Reversed sort modes are applied at read time — `iter_entries()`
+   reverses the iterator and `get()` mirrors the index. Nothing re-sorts on reversal (see `sort()`, which
+   short-circuits when only the direction changed).
+2. `..` is a synthetic entry in the separate `dotdot` field, displayed at index 0 and absent from `entries`.
+   `len()`, `get()`, and anything consuming `selected()` must account for the +1 offset.
+
+Any new accessor that maps a selection index to a `DirEntry` must go through `get()` rather than indexing
+`entries`.
+
+Other things worth knowing before editing:
+
+- `rentries` has 1 subtracted because Ceph counts the directory itself.
+- Off-Ceph, directory sizes are deliberately discarded (`e.size = None`) and `total_size` forced to 0, since
+  non-Ceph dir sizes are meaningless here; a warning message is shown. The app is expected to run on non-Ceph
+  paths, so keep that path working.
+- `select_next`/`select_prev` intentionally clamp instead of using `ListState::select_next`, because item
+  highlighting is applied manually per-`ListItem` in `to_listitem` rather than via ratatui's highlight style —
+  scrolling past the end would drop the highlight for one frame.
+- The highlighted entry per directory is remembered in `App::highlighted` (keyed by cwd) and restored by name,
+  falling back to index. On the first arrival in a directory there is nothing to restore, so
+  `select_first_entry()` skips `..` and lands on the first real entry; `select_first()` is the literal top of the
+  list and stays bound to Home/`g`. Refresh and Backspace go through the remembered path, so they don't jump.
+- `POPUP_TEXT_HEIGHT` in [ui.rs](src/ui.rs) is a fixed constant that popup scroll clamping and scrollbar state
+  depend on; the popup is not sized to the terminal.
+- The gauge in `gauge()` draws the percentage text *inside* the bar with inverted colors on the overlapping
+  region, using ⅛-block characters for sub-cell precision. Sizes/counts use base-1000 units.
+- Times shown are `rctime` for directories and `ctime` for files — deliberately ctime, not mtime; see the
+  `after_help` text in [main.rs](src/main.rs).
+
+## Tests
+
+Unit tests are inline `#[cfg(test)]` modules, since this is a binary crate with no lib target and integration
+tests can't import it. Anything needing the built binary goes in [tests/](tests/) and finds it via
+`env!("CARGO_BIN_EXE_cephdu")`; scratch trees go under `env!("CARGO_TARGET_TMPDIR")`. There is no `tempfile`
+dependency, deliberately — cargo already provides both paths.
+
+- [src/app.rs](src/app.rs) — the index-mapping traps above. `DirListing::from_entries` is a `#[cfg(test)]`
+  constructor that takes entries directly, so sorting and selection can be tested without a filesystem.
+- [src/ui.rs](src/ui.rs) — full-frame snapshots via ratatui's `TestBackend`. The app under test is built from a
+  synthetic listing *and* a faked `cwd`, so the frame doesn't depend on the filesystem or the path the tests run
+  from; only the version line is excluded from the golden. Regenerate a golden by printing the frame lines with
+  `{:?}` rather than hand-editing the box-drawing characters. Both optional columns don't fit in 80 columns, so
+  that one test renders at 120.
+- [tests/ceph.rs](tests/ceph.rs) — the only coverage of the xattrs themselves, and the only tests that can't run
+  in CI. They skip (not fail) with a `SKIP` notice when no CephFS is available, so `cargo test` is green
+  everywhere. The MDS updates recursive stats asynchronously, so assertions poll until the tree settles;
+  expect these to take ~10s.
+
+Two things make the assertions filesystem-independent and are easy to get wrong when adding tests: directory
+sizes and counts are `None` off Ceph (so tests either use file sizes, which `stat` always reports, or key off the
+binary's own "not a Ceph directory" warning), and timestamps in fixtures are mid-year and mid-day so no timezone
+can shift the year that gets rendered.
+
+## Conventions
+
+Comment the non-obvious *why*, invariants, and traps — not what the code says. Rationale for a change belongs in
+the commit message. Commit messages in this repo are prefixed with the module (`app:`, `ui:`, `readme:`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,17 @@ Other things worth knowing before editing:
   Creating something *inside* a directory sets the parent's rctime, since that changes the parent's own ctime,
   so it is only the leaves of a fresh tree that read zero. There is no third option to fall back on either:
   CephFS exposes no birth time (`ls --time=birth` reports `?`).
+- The info panel (`i`, or `-i`/`--info` to start with it shown — the flag conflicts with the flat modes, whose
+  format must not grow columns; issues #9/#16/#17) is where non-recursive numbers live, in words, so the listing's
+  every-number-is-recursive rule stays intact. Its this-level values come from the listing in hand (works off
+  Ceph); its recursive lines are a fresh four-xattr snapshot of the cwd — consistent with each other, though
+  transiently not necessarily with the border or the this-level sums, and that trade (internal consistency over
+  agreement) is deliberate. A panel renders every frame, so `App::info` caches the snapshot as *numbers*, taken
+  only at the toggle and again when a listing lands (`compute_info`) — never in the render path — and formatting
+  happens per frame so `e` reformats it. Its height varies with which lines the filesystem could fill, and the
+  listing's bottom border doubles as its top, which is why `render_list` switches that border's corners to
+  connectors while the panel is up. `rsubdirs` is the only r-attr that counts the directory itself;
+  files-per-dir divides by it *un*subtracted so a flat directory doesn't divide by zero.
 - Times shown are `rctime` for directories and `ctime` for files — deliberately ctime, not mtime; see the
   `after_help` text in [main.rs](src/main.rs).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,11 @@ Other things worth knowing before editing:
   The white foreground is for light terminals: with an inherited foreground the text would be dark on a dark
   band there. Inheriting it instead is the one-line change that keeps the text from shifting color at all, at
   that cost.
+  Under `NO_COLOR` the band would simply disappear, because crossterm drops color sequences and keeps
+  attributes, leaving the `> ` marker as the only cue. `selected_style(colors_disabled())` therefore falls back
+  to bold, which is why the gauge still has to remove `BOLD` from its own spans. Tests that assert the row's
+  colors read them from `selected_style(colors_disabled())` rather than naming them, so `NO_COLOR=1 cargo test`
+  passes too.
   Two alternatives were tried and rejected. Reverse video adapts to any terminal for free, but it inverts the
   gauges: a `█` reversed is drawn in the background color while a reversed empty cell paints the foreground
   across its full width, so a bar shows the wrong value. Marker-and-bold alone, with no background, reads as too

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ pre-commit run --all-files
 cargo test
 cargo test --bin cephdu          # unit tests only (fast, no filesystem)
 cargo test <substring>           # one test, e.g. cargo test renders_the_listing
-cargo test -- --nocapture        # needed to see the SKIP notices from tests/ceph.rs
+cargo test -- --nocapture        # SKIP notices from tests/ceph.rs, syscall table from tests/syscalls.rs
 CEPHDU_TEST_DIR=<ceph path> cargo test --test ceph
 ```
 
@@ -61,7 +61,8 @@ redirected — hence flat mode is implied when stdout isn't a terminal, with `--
 pty-wrapping tools. Two properties of flat mode are deliberate and worth preserving:
 
 - `--flat` (`-f`) selects the format with units and `--parseable` (`-p`) the raw one. Neither varies with the
-  terminal, so parsers see the same bytes however the tool is invoked. This is also why flat mode has no column-visibility flags: the TUI's `u`/`t` toggles exist
+  terminal, so parsers see the same bytes however the tool is invoked. This is also why flat mode has no
+  column-visibility flags: the TUI's `u`/`t` toggles exist
   because terminal width is scarce, a pipe has no such limit, and a fixed column set keeps field offsets stable.
   It also leaves the remaining `-<key>` short flags free for the startup sort flags in issue #11.
 - An implied flat listing (no flag, stdout not a terminal) is parseable rather than human, on the grounds that a
@@ -107,6 +108,35 @@ Other things worth knowing before editing:
   the size shown is the link's own (the length of the path it holds), a directory symlink sorts among the files,
   and `Enter` on one does nothing, since `try_cd` canonicalizes and going back through a symlink would need that
   reworked.
+- `Options` is what a read needs to know — sort mode, `dirs_first`, `owners` — and travels as one value rather
+  than a run of booleans, which is what `DirListing::from` and `App::new` take.
+- `DirListing::options.owners` records what that listing *was read with*, not what the next read should do. The
+  distinction matters: `toggle_owner` re-reads only when the listing never had owners, so hiding the column and
+  showing it again is free however many times, while `try_cd` builds the next read's options from
+  `App::needs()` so leaving with a column hidden doesn't make the next directory pay. Conflating the two made the
+  third press of `u` re-read; there are tests with sentinel values for both fields. `App::needs()` is also where
+  *ordering* by a field counts as needing it: sorting by owner or by time without reading them silently sorted
+  by nothing, which is a bug worth not reintroducing.
+- `-l` implies `--flat` and conflicts with `--tui`: a flat listing is the one with no way to ask later, while
+  the interface has `u` and `t`, which read on demand. That is why it selects a mode rather than being ignored
+  in one.
+- `owners` and `times` are off by default and are the deferred-read work for #7. They matter for very different
+  reasons, and the benchmark is the reason to keep them separate from the cheap fields: on ten thousand
+  directories a listing went 43s to 30s, and 84% of the remaining time is `lgetxattr` at 1.37ms a call. The
+  `statx` deferral is worth only ~4%, because CephFS's `readdir` prefetches inode metadata into the client cache
+  so the stat is served locally; the xattrs are not prefetched, so each is a round trip. Dropping `rctime` — one
+  of the three — is what bought the 12 seconds. Anything further has to come from issuing those calls
+  concurrently rather than one at a time (#18).
+- A directory needs a stat for *nothing else* than the owner: its size, count and time are the r-attrs and its
+  kind comes from readdir via
+  `DirEntry::file_type()`, which uses `d_type` and only falls back to a stat of its own on `DT_UNKNOWN` (CephFS
+  does return it — measured). A file still needs its stat for size and time, so for files the only saving is the
+  name lookup, which is why `DirEntry::from` takes `owners` separately from `stat` rather than deriving the
+  owner from whatever stat happens to be in hand. That saving is small: measured on Rusty, where nsswitch is
+  `files sss`, a real user resolves from SSSD's cache in ~18µs against 1.37ms for one `lgetxattr`, and only
+  *absent* uids are slow (~2.3ms) — a real directory has none. So the owner's cost is its per-directory stat,
+  not the lookup; don't reinstate the claim that it means an LDAP round trip.
+  [tests/syscalls.rs](tests/syscalls.rs) pins the resulting cost model and prices `-l`.
 - `rentries` has 1 subtracted because Ceph counts the directory itself. Specifically it is `rsubdirs` that
   includes the directory, since `rentries == rfiles + rsubdirs`; the non-recursive `ceph.dir.entries` has no such
   self-count.
@@ -142,7 +172,8 @@ Other things worth knowing before editing:
   marker, and deliberately *not* bold — bold brightens the text on top of the color change, so the row reads as
   lightening rather than as marked. Grey rather than blue because `Color::Blue` is ANSI 4, already the darkest blue in
   the 16, so on a theme that renders it brightly there is nothing left to raise the contrast with; `DarkGray` is
-  the only named color darker than it that won't merge into a dark terminal's own background. Going darker still means leaving
+  the only named color darker than it that won't merge into a dark terminal's own background. Going darker
+  still means leaving
   the 16 for `Indexed`/`Rgb`, defensible only here, where both halves of the pair are named and so carry their
   own contrast.
   The white foreground is for light terminals: with an inherited foreground the text would be dark on a dark
@@ -176,6 +207,16 @@ Other things worth knowing before editing:
   the unit forms fit in, which is what keeps the golden frame stable when the mode is off.
 - Frame rows contain three-byte box and block characters, so a test that locates a column with `str::rfind` gets
   a byte offset, not a screen column. Convert with `line[..byte].chars().count()`.
+- `ceph.dir.rctime` is the newest ctime anywhere in the subtree, *including* every directory's own: `chmod` on
+  the directory alone moves it, and so does `chmod` on any subdirectory (measured, not assumed — an earlier
+  version of the help text claimed it excluded the directory itself). It is a *propagated* value that starts at
+  zero, though: creating a directory sets its ctime but not its rctime, so one that nothing has happened in
+  since it was made reports zero and renders as the epoch. That is deliberate — the epoch is how a Unix
+  timestamp says "never set" — and common: a freshly created tree of empty directories shows it everywhere,
+  where `ls -l` shows a date, because `ls` shows the directory's *own* mtime and creation does set that.
+  Creating something *inside* a directory sets the parent's rctime, since that changes the parent's own ctime,
+  so it is only the leaves of a fresh tree that read zero. There is no third option to fall back on either:
+  CephFS exposes no birth time (`ls --time=birth` reports `?`).
 - Times shown are `rctime` for directories and `ctime` for files — deliberately ctime, not mtime; see the
   `after_help` text in [main.rs](src/main.rs).
 
@@ -193,6 +234,15 @@ dependency, deliberately — cargo already provides both paths.
   from; only the version line is excluded from the golden. Regenerate a golden by printing the frame lines with
   `{:?}` rather than hand-editing the box-drawing characters. Both optional columns don't fit in 80 columns, so
   that one test renders at 120.
+- [tests/syscalls.rs](tests/syscalls.rs) — the cost of a listing in syscalls, via `strace -c`, for #7. It
+  measures a *slope*: two trees differing by a known number of entries, counts subtracted, so the fixed cost of
+  starting a process cancels and the numbers don't move with the libc or kernel underneath. Today a listing costs
+  one `statx` per file, two `lgetxattr` per directory and no stat for a directory at all, and nothing else
+  scales — that last part is the
+  assertion worth keeping, since an accidental per-entry syscall is what makes a large directory slow. Skips
+  without strace or ptrace permission. It cannot see the Ctrl-C poll in `ls()`, which only costs a syscall when
+  crossterm's event source initialises, and that needs a controlling terminal: under a test runner /dev/tty
+  fails with ENXIO, so the interface may pay one more syscall per entry than the harness reports.
 - [tests/ceph.rs](tests/ceph.rs) — the only coverage of the xattrs themselves, and the only tests that can't run
   in CI. They skip (not fail) with a `SKIP` notice when no CephFS is available, so `cargo test` is green
   everywhere. The MDS updates recursive stats asynchronously, so assertions poll until the tree settles;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,14 @@ runtime, unit tests included. The moving parts and their traps:
   total, priced upfront from `ceph.dir.entries` — one more constant xattr read per listing, deliberately not
   taken from a full readdir pass first: stats lean on readdir's prefetch staying cached, and on a huge
   directory a drain-then-stat ordering would let it expire.
+- The hidden `-j` flag (`Options::jobs`) fans the per-entry syscalls out over scoped worker threads,
+  `read_batched`. It is deliberately undocumented — it changes speed, never output, and may change or vanish —
+  so keep it out of the README and the help text; tests pin both the hiding and the output equality. The feed
+  channel is bounded for the same prefetch reason as above, but streams rather than batching, because the
+  readdir is itself a substantial serial cost (readdirplus, ~750µs/entry on Ceph) and overlapping it with the
+  workers is most of the win beyond ~4 jobs. `jobs == 1` must keep taking the sequential loop, whose exact
+  syscall pattern the slope test pins — under `-j` only the statx/lgetxattr slopes are pinned, since thread
+  plumbing scales with the work.
 - A worker's answer is applied only if its generation matches the one `pending` — superseding (a `cd` during a
   `cd`) and cancelling both orphan the old answer, which may still arrive and must be dropped, not applied.
   Anything that changes what a listing shows goes through `start_listing`/`on_listing_msg`; there is no

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,8 @@ dependencies = [
  "lazy_static",
  "libc",
  "ratatui",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -202,7 +204,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -272,6 +274,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
+ "futures-core",
  "mio",
  "parking_lot",
  "rustix",
@@ -310,7 +313,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -321,7 +324,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -367,6 +370,12 @@ name = "foldhash"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "gimli"
@@ -443,7 +452,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -779,7 +788,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -794,6 +803,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +821,38 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -920,7 +972,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
  "wasm-bindgen-shared",
 ]
 
@@ -942,7 +994,7 @@ checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -999,7 +1051,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1010,7 +1062,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ categories = ["command-line-utilities", "filesystem"]
 chrono = "0.4"
 clap = { version = "4.5.31", features = ["derive"] }
 color-eyre = "0.6.3"
-crossterm = "0.28.1"
+crossterm = { version = "0.28.1", features = ["event-stream"] }
 lazy_static = "1.5.0"
 libc = "0.2.170"
 ratatui = "0.29.0"
+tokio = { version = "1", features = ["rt", "sync", "macros", "time"] }
+tokio-stream = "0.1"

--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ The listing scrolls sideways with the left and right arrow keys when the rows ar
 wider than the terminal, which happens once the owner or time columns are shown.
 The whole listing moves, gauges included; the border and its labels stay put.
 
+### Slow directories
+Reading a directory costs a round trip to the metadata server per entry, so a
+huge one can take minutes. The interface doesn't block on it: the directory
+already on screen stays usable while the read runs, a notice counts the entries
+read so far, and `Esc` or `Ctrl-C` stops the read and stays put. Navigating
+somewhere else simply abandons the read in favor of the new one, quitting never
+waits, and the interface appears immediately at startup even when the first
+directory is slow. A read that finishes promptly shows none of this.
+
 ## Flat text mode
 `cephdu --flat` prints the listing as text instead of drawing the interactive
 interface, with the same units the interface uses:

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ the column reads as one chart. Flat listings are never colored.
 `NO_COLOR` is honored. Since it suppresses colors but not attributes, a colored
 band would simply disappear, so the cursor row falls back to bold when it is set.
 
+### Symlinks
+Symlinks are marked the way `ls -F` marks them, with a trailing `@` beside the `/`
+that directories already carry. The size shown is the symlink's own — the length of
+the path it holds — rather than its target's, and a symlink to a directory is listed
+among the files. Following one is not implemented yet.
+
 ### Reading the border
 The top border shows the current path on the left and the directory's totals on
 the right. A path too long for the border loses its start, marked with `…`, so
@@ -122,7 +128,9 @@ interface, with the same units the interface uses:
 tab-separated fields per entry — size in bytes, recursive entry count,
 modification time in Unix seconds, user, group, and name — with `-` for anything
 the filesystem doesn't provide (recursive values are only available on Ceph).
-Directory names keep their trailing `/`, and `..` is not listed.
+Directory names keep their trailing `/`, and `..` is not listed. Symlinks are *not*
+marked here: a filename may contain `@`, so a parser could not tell a mark from a
+character. Only the two human formats mark them.
 
 ```console
 ❯ cephdu --parseable /mnt/ceph/users/$USER | head -3

--- a/README.md
+++ b/README.md
@@ -56,8 +56,24 @@ Options:
   -f, --flat       Print a flat text listing, with units, instead of the interactive interface
   -p, --parseable  Print a flat text listing of raw values, for parsing
       --tui        Use the interactive interface even if stdout is not a terminal
+  -n, --name       Sort by name
+  -s, --size       Sort by size
+  -c, --count      Sort by file count
+  -u, --owner      Sort by owner
+  -t, --time       Sort by modification time
+  -r, --reverse    Reverse the sort order
   -h, --help       Print help
 ```
+
+### Sorting
+Listings are sorted largest first unless one of `-n`, `-s`, `-c`, `-u` or `-t` is
+given, which choose the field to sort on. They apply to both the interactive
+interface and flat listings, and each field starts in the direction its sort key
+uses in the interface: sizes, counts and times read most-first, names and owners
+read ascending. In the interface, pressing the field's key reverses it from there.
+
+`-r` reverses whichever order is in effect and combines with the field flags, so
+`cephdu -r` reads smallest first and `cephdu -nr` reverses the name order.
 
 ## Flat text mode
 `cephdu --flat` prints the listing as text instead of drawing the interactive
@@ -73,8 +89,7 @@ interface, with the same units the interface uses:
 tab-separated fields per entry — size in bytes, recursive entry count,
 modification time in Unix seconds, user, group, and name — with `-` for anything
 the filesystem doesn't provide (recursive values are only available on Ceph).
-Directory names keep their trailing `/`, and `..` is not listed. Rows are sorted
-largest first.
+Directory names keep their trailing `/`, and `..` is not listed.
 
 ```console
 ❯ cephdu --parseable /mnt/ceph/users/$USER | head -3

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ colors it does name are the row the cursor is on, and red and yellow for errors 
 warnings. The bars keep the terminal's own color on every row, cursor included, so
 the column reads as one chart. Flat listings are never colored.
 
+`NO_COLOR` is honored. Since it suppresses colors but not attributes, a colored
+band would simply disappear, so the cursor row falls back to bold when it is set.
+
 ### Reading the border
 The top border shows the current path on the left and the directory's totals on
 the right. A path too long for the border loses its start, marked with `…`, so

--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ The whole listing moves, gauges included; the border and its labels stay put.
 Reading a directory costs a round trip to the metadata server per entry, so a
 huge one can take minutes. The interface doesn't block on it: the directory
 already on screen stays usable while the read runs, a notice counts the entries
-read so far, and `Esc` or `Ctrl-C` stops the read and stays put. Navigating
+read so far — against the directory's total, which on Ceph is known upfront — and
+`Esc` or `Ctrl-C` stops the read and stays put. Navigating
 somewhere else simply abandons the read in favor of the new one, quitting never
 waits, and the interface appears immediately at startup even when the first
 directory is slow. A read that finishes promptly shows none of this.

--- a/README.md
+++ b/README.md
@@ -47,14 +47,54 @@ The CLI accepts one optional argument, the initial directory:
 ❯ cephdu --help
 Display ceph space and file count (inode) usage in an interactive terminal
 
-Usage: cephdu [PATH]
+Usage: cephdu [OPTIONS] [PATH]
 
 Arguments:
   [PATH]  Path to the directory to display
 
 Options:
-  -h, --help  Print help
+  -f, --flat       Print a flat text listing, with units, instead of the interactive interface
+  -p, --parseable  Print a flat text listing of raw values, for parsing
+      --tui        Use the interactive interface even if stdout is not a terminal
+  -h, --help       Print help
 ```
+
+## Flat text mode
+`cephdu --flat` prints the listing as text instead of drawing the interactive
+interface, with the same units the interface uses:
+```console
+❯ cephdu --flat /mnt/ceph/users/$USER | head -3
+ 1.1 TB   48.2 K  Dec 11 09:15  alice:scc  data/
+ 2.1 GB        1  Dec 10 23:53  alice:scc  bigfile.h5
+ 4.1 KB       12  Dec 10 23:36  alice:scc  scripts/
+```
+
+`--parseable` prints the same listing as raw values instead, one row of six
+tab-separated fields per entry — size in bytes, recursive entry count,
+modification time in Unix seconds, user, group, and name — with `-` for anything
+the filesystem doesn't provide (recursive values are only available on Ceph).
+Directory names keep their trailing `/`, and `..` is not listed. Rows are sorted
+largest first.
+
+```console
+❯ cephdu --parseable /mnt/ceph/users/$USER | head -3
+1099511627776	48213	1765432100	alice	scc	data/
+2147483648	1	1765400000	alice	scc	bigfile.h5
+4096	12	1765399000	alice	scc	scripts/
+```
+
+The parseable format does not change based on whether stdout is a terminal, so it
+stays parsable regardless of how it is invoked:
+```console
+❯ cephdu -p | awk -F'\t' '$1 > 1e12 {print $6}'    # directories over 1 TB
+```
+
+Because the interactive interface draws to stdout, a flat listing is printed
+automatically when stdout is not a terminal, so `cephdu | ...` and `cephdu > file`
+do something useful. That implied listing is parseable, on the grounds that
+whatever is reading a pipe is more often a program than a person. Pass `--tui` to
+override the detection, which is occasionally needed under tools that run a
+program on a pseudo-terminal.
 
 ## Availability on Flatiron Institute Clusters
 

--- a/README.md
+++ b/README.md
@@ -129,11 +129,12 @@ it conflicts with `--tui`. Without it, `--flat` drops the owner column, while ev
 other column stays and shows `-` for what is missing; `--parseable` always keeps all
 six fields.
 
-The interface asks instead: `u` and `t` read what they need when pressed and keep it
-afterwards, so toggling a column off and on costs nothing. Moving to another
-directory or refreshing reads afresh, and reads only what the visible columns and the
-current sort need — so ordering by owner or by change time fetches it whether or not
-the column is on screen.
+The interface asks instead: `u` and `t` fetch just the missing values for the listing
+already on screen — not a re-read of the directory — and keep them for as long as you
+stay there, so toggling the columns in any order costs nothing after the first fetch
+of each. Moving to another directory or refreshing reads afresh, and reads only what
+the visible columns and the current sort need — so ordering by owner or by change
+time fetches it whether or not the column is on screen.
 
 A directory's time is Ceph's `rctime`: the newest ctime anywhere beneath it, its own
 included, so changing only its permissions moves it. It is a propagated value that

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ whatever is reading a pipe is more often a program than a person. Pass `--tui` t
 override the detection, which is occasionally needed under tools that run a
 program on a pseudo-terminal.
 
+## Tests
+```console
+cargo test
+```
+The tests in `tests/ceph.rs` cover the recursive xattrs, so they need a CephFS
+mount and skip themselves when there isn't one. They put a scratch tree in
+`/mnt/ceph/users/$USER` by default; set `CEPHDU_TEST_DIR` to use somewhere else.
+
 ## Availability on Flatiron Institute Clusters
 
 `cephdu` is available under the `fi-utils` module on the Flatiron Institute clusters, rusty and popeye, and is the preferred way to look at disk usage on ceph.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ The bottom border of the interface names the sort in effect, as in `size ↓` fo
 largest first or `name ↑` for A to Z, and appends `· dirs first` while directories
 are being grouped.
 
+### Scrolling
+The listing scrolls sideways with the left and right arrow keys when the rows are
+wider than the terminal, which happens once the owner or time columns are shown.
+The whole listing moves, gauges included; the border and its labels stay put.
+
 ## Flat text mode
 `cephdu --flat` prints the listing as text instead of drawing the interactive
 interface, with the same units the interface uses:

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ The bottom border of the interface names the sort in effect, as in `size ↓` fo
 largest first or `name ↑` for A to Z, and appends `· dirs first` while directories
 are being grouped.
 
+### Reading the border
+The top border shows the current path on the left and the directory's totals on
+the right. A path too long for the border loses its start, marked with `…`, so
+that the deepest components stay visible as you navigate.
+
 ### Scrolling
 The listing scrolls sideways with the left and right arrow keys when the rows are
 wider than the terminal, which happens once the owner or time columns are shown.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The literal string `$USER` is substituted at runtime.
 At runtime, the `CEPHDU_DEFAULT_DIR` environment variable overrides the baked-in
 value, with the same `$USER` substitution — so a site can set the default per
 cluster, in a modulefile for example, instead of per build. Setting it to the
-empty string disables the baked-in default too. Either default applies only when
+empty string disables the baked-in default, too. Either default applies only when
 no path is given and the current directory is not on Ceph; a Ceph current
 directory always wins.
 
@@ -47,7 +47,7 @@ cargo build --release cargo build --target=x86_64-unknown-linux-musl
 ```
 
 ## Usage
-Simply run `cephdu` from the command line and an interactive terminal user interface (TUI) will be displayed. Navigate using the arrow keys and Enter. For a full list of keyboard shortcuts, press `?`.
+Simply run `cephdu` from the command line and an interactive terminal user interface (TUI) will be displayed. Navigate using the arrow keys and Enter. For a full list of keyboard shortcuts, press `?`. For [`flat mode`](#flat-text-mode), use `cephdu -f`.
 
 The CLI accepts one optional argument, the initial directory. Without it, cephdu
 starts in the current directory if that is on Ceph, and otherwise in
@@ -79,8 +79,37 @@ Options:
   -h, --help        Print help
 ```
 
+## Flat text mode
+`cephdu -f/--flat` prints the listing as text instead of drawing the interactive
+interface, with the same units the interface uses:
+```console
+❯ cephdu --flat /mnt/ceph/users/$USER | head -3
+88.8 TB   95.6 K             -  Derivatives/
+23.3 TB  232.8 K             -  AbacusSummit/
+ 1.0 GB        -  Mar 23 16:13  file.bin
+```
+
+Note that directory rctime is not displayed by default to avoid potentially expensive syscalls. Use `-l` to display.
+
+`--parseable` prints the same listing as raw values instead, one row of six
+tab-separated fields per entry — size in bytes, recursive entry count,
+change time in Unix seconds, user, group, and name — with `-` for anything
+the filesystem doesn't provide (recursive values are only available on Ceph).
+Directory names keep their trailing `/`, and `..` is not listed. Symlinks are *not*
+marked here: a filename may contain `@`, so a parser could not tell a mark from a
+character. Only the two human formats mark them.
+
+```console
+❯ cephdu --parseable /mnt/ceph/users/$USER | head -3
+88830194877352  95636   -       -       -       Derivatives/
+23303634816992  232846  -       -       -       AbacusSummit/
+1048576000      -       1774296835      -       -       test1.bin
+```
+
+Parseable is the default when stdout is not a TTY.
+
 ### Sorting
-Listings are sorted largest first unless one of `-n`, `-s`, `-c`, `-u` or `-t` is
+Listings are sorted by bytes (`rbytes` for directories) unless one of `-n`, `-s`, `-c`, `-u` or `-t` is
 given, which choose the field to sort on. They apply to both the interactive
 interface and flat listings, and each field starts in the direction its sort key
 uses in the interface: sizes, counts and change times read most-first, names and
@@ -97,67 +126,26 @@ within each group by the usual rules. In the interactive interface, `d` toggles 
 when the rounding matters; `e` toggles it in the interface. The parseable format is
 always exact, so `-e` has no effect there.
 
-The bottom border of the interface names the sort in effect, as in `size ↓` for
-largest first or `name ↑` for A to Z, and appends `· dirs first` while directories
-are being grouped.
-
 ### Colors
-The interface names as few colors as it can, inheriting the terminal's own, so it
-suits a light terminal as well as a dark one without being told which it is. The
-colors it does name are the row the cursor is on, and red and yellow for errors and
-warnings. The bars keep the terminal's own color on every row, cursor included, so
-the column reads as one chart. Flat listings are never colored.
-
-`NO_COLOR` is honored. Since it suppresses colors but not attributes, a colored
-band would simply disappear, so the cursor row falls back to bold when it is set.
+The interface mostly uses terminal colors, so it should adapt to dark and light themes. The program respects `NO_COLOR`. Flat mode never uses colors.
 
 ### Symlinks
 Symlinks are marked the way `ls -F` marks them, with a trailing `@` beside the `/`
 that directories already carry. The size shown is the symlink's own — the length of
 the path it holds — rather than its target's, and a symlink to a directory is listed
-among the files. Following one is not implemented yet.
+among the files.
 
-### What costs extra, and `-l`
-Two things are not read unless something asks for them, because each one costs extra
-syscalls — and on Ceph each of those is a round trip to the metadata server:
 
-* **The owner.** It is the only thing a directory needs a `stat` for — size and
-  count are xattrs and the kind comes from `readdir`. Turning the uid into a name is
-  cheap by comparison, and happens once per distinct owner rather than once per
-  entry.
-* **A directory's recursive time.** It is one of the three xattr reads a directory
-  otherwise makes, and those reads dominate a large listing: on ten thousand
-  directories, `43s` with `-l` against `30s` without.
+### syscalls
+In a directory listing, we query the following info by default:
+- For each directory: `rbytes` and `rentries`. Two `getxattr` syscalls.
+- For each file: one `stat`, yielding the file size, ctime, etc.
 
-So without `-l` a directory costs two xattr reads and no `stat` at all, and a uid is
-never turned into a name.
-
-A file's size and change time come from the one `stat` it needs regardless, so they
-are always shown.
-
-`-l` implies `-f`, since a flat listing is the one with no way to ask later, and so
-it conflicts with `--tui`. Without it, `--flat` drops the owner column, while every
-other column stays and shows `-` for what is missing; `--parseable` always keeps all
-six fields.
-
-The interface asks instead: `u` and `t` fetch just the missing values for the listing
-already on screen — not a re-read of the directory — and keep them for as long as you
-stay there, so toggling the columns in any order costs nothing after the first fetch
-of each. Moving to another directory or refreshing reads afresh, and reads only what
-the visible columns and the current sort need — so ordering by owner or by change
-time fetches it whether or not the column is on screen.
-
-A directory's time is Ceph's `rctime`: the newest ctime anywhere beneath it, its own
-included, so changing only its permissions moves it. It is a propagated value that
-starts at zero — creating a directory does not give it one — so a directory nothing
-has happened in since it was made shows the epoch, the usual way a Unix timestamp
-says it was never set. `ls -l` shows a date there instead, because it shows the
-directory's *own* mtime, which creation does set. Creating something inside a
-directory does set the parent's, so only the leaves of a fresh tree read the epoch.
+If the user requests displaying or sorting by ctime or owner, then we issue an additional syscall (`getxattr` or `stat`) for each directory entry.
 
 ### Directory info
 Every number in the listing is recursive, so the non-recursive ones live in a
-panel that `i` toggles under the listing, labeled in words:
+panel that `i` toggles under the listing:
 
 ```
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
@@ -170,73 +158,12 @@ panel that `i` toggles under the listing, labeled in words:
 ┗ size ↓ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Press ? for help ┛
 ```
 
-"At this level" means the files directly in this directory, the way `du -S`
-counts — so that line answers whether the usage is here or somewhere below. The
-panel follows you as you navigate, and `-i` opens the interface with it shown. Its this-level numbers come from the listing
-already in hand; the recursive ones are read from the directory's own attributes
-when the panel opens or the directory changes, four reads in all, so it costs
-nothing per entry. Off Ceph the recursive lines are absent. The recursive lines
+`-i` opens the interface with the panel shown.
+
+"At this level" means the files directly in this directory. Off Ceph the recursive lines are absent. The recursive lines
 are a consistent snapshot, which can disagree slightly with the border's totals
 while Ceph is still propagating recent changes; each number is individually
 true.
-
-### Reading the border
-The top border shows the current path on the left and the directory's totals on
-the right. A path too long for the border loses its start, marked with `…`, so
-that the deepest components stay visible as you navigate.
-
-### Scrolling
-The listing scrolls sideways with the left and right arrow keys when the rows are
-wider than the terminal, which happens once the owner or time columns are shown.
-The whole listing moves, gauges included; the border and its labels stay put.
-
-### Slow directories
-Reading a directory costs a round trip to the metadata server per entry, so a
-huge one can take minutes. The interface doesn't block on it: the directory
-already on screen stays usable while the read runs, a notice counts the entries
-read so far — against the directory's total, which on Ceph is known upfront — and
-`Esc` or `Ctrl-C` stops the read and stays put. Navigating
-somewhere else simply abandons the read in favor of the new one, quitting never
-waits, and the interface appears immediately at startup even when the first
-directory is slow. A read that finishes promptly shows none of this.
-
-## Flat text mode
-`cephdu --flat` prints the listing as text instead of drawing the interactive
-interface, with the same units the interface uses:
-```console
-❯ cephdu --flat /mnt/ceph/users/$USER | head -3
- 1.1 TB   48.2 K  Dec 11 09:15  alice:scc  data/
- 2.1 GB        1  Dec 10 23:53  alice:scc  bigfile.h5
- 4.1 KB       12  Dec 10 23:36  alice:scc  scripts/
-```
-
-`--parseable` prints the same listing as raw values instead, one row of six
-tab-separated fields per entry — size in bytes, recursive entry count,
-change time in Unix seconds, user, group, and name — with `-` for anything
-the filesystem doesn't provide (recursive values are only available on Ceph).
-Directory names keep their trailing `/`, and `..` is not listed. Symlinks are *not*
-marked here: a filename may contain `@`, so a parser could not tell a mark from a
-character. Only the two human formats mark them.
-
-```console
-❯ cephdu --parseable /mnt/ceph/users/$USER | head -3
-1099511627776	48213	1765432100	alice	scc	data/
-2147483648	1	1765400000	alice	scc	bigfile.h5
-4096	12	1765399000	alice	scc	scripts/
-```
-
-The parseable format does not change based on whether stdout is a terminal, so it
-stays parsable regardless of how it is invoked:
-```console
-❯ cephdu -p | awk -F'\t' '$1 > 1e12 {print $6}'    # directories over 1 TB
-```
-
-Because the interactive interface draws to stdout, a flat listing is printed
-automatically when stdout is not a terminal, so `cephdu | ...` and `cephdu > file`
-do something useful. That implied listing is parseable, on the grounds that
-whatever is reading a pipe is more often a program than a person. Pass `--tui` to
-override the detection, which is occasionally needed under tools that run a
-program on a pseudo-terminal.
 
 ## Tests
 ```console

--- a/README.md
+++ b/README.md
@@ -54,16 +54,17 @@ Arguments:
 
 Options:
   -f, --flat        Print a flat text listing, with units, instead of the interactive interface
-  -p, --parseable   Print a flat text listing of raw values, for parsing
+  -p, --parseable   Print a flat text listing of raw values for parsing
       --tui         Use the interactive interface even if stdout is not a terminal
   -n, --name        Sort by name
   -s, --size        Sort by size
   -c, --count       Sort by file count
   -u, --owner       Sort by owner
-  -t, --time        Sort by modification time
+  -t, --time        Sort by change time
   -r, --reverse     Reverse the sort order
   -d, --dirs-first  List directories before files
   -e, --exact       Show sizes and counts in full instead of scaled to a unit
+  -l, --long        Show the owner and directory times, which cost extra syscalls. Implies -f
   -h, --help        Print help
 ```
 
@@ -71,8 +72,9 @@ Options:
 Listings are sorted largest first unless one of `-n`, `-s`, `-c`, `-u` or `-t` is
 given, which choose the field to sort on. They apply to both the interactive
 interface and flat listings, and each field starts in the direction its sort key
-uses in the interface: sizes, counts and times read most-first, names and owners
-read ascending. In the interface, pressing the field's key reverses it from there.
+uses in the interface: sizes, counts and change times read most-first, names and
+owners read ascending. In the interface, pressing the field's key reverses it from
+there.
 
 `-r` reverses whichever order is in effect and combines with the field flags, so
 `cephdu -r` reads smallest first and `cephdu -nr` reverses the name order.
@@ -104,6 +106,43 @@ that directories already carry. The size shown is the symlink's own — the leng
 the path it holds — rather than its target's, and a symlink to a directory is listed
 among the files. Following one is not implemented yet.
 
+### What costs extra, and `-l`
+Two things are not read unless something asks for them, because each one costs extra
+syscalls — and on Ceph each of those is a round trip to the metadata server:
+
+* **The owner.** It is the only thing a directory needs a `stat` for — size and
+  count are xattrs and the kind comes from `readdir`. Turning the uid into a name is
+  cheap by comparison, and happens once per distinct owner rather than once per
+  entry.
+* **A directory's recursive time.** It is one of the three xattr reads a directory
+  otherwise makes, and those reads dominate a large listing: on ten thousand
+  directories, `43s` with `-l` against `30s` without.
+
+So without `-l` a directory costs two xattr reads and no `stat` at all, and a uid is
+never turned into a name.
+
+A file's size and change time come from the one `stat` it needs regardless, so they
+are always shown.
+
+`-l` implies `-f`, since a flat listing is the one with no way to ask later, and so
+it conflicts with `--tui`. Without it, `--flat` drops the owner column, while every
+other column stays and shows `-` for what is missing; `--parseable` always keeps all
+six fields.
+
+The interface asks instead: `u` and `t` read what they need when pressed and keep it
+afterwards, so toggling a column off and on costs nothing. Moving to another
+directory or refreshing reads afresh, and reads only what the visible columns and the
+current sort need — so ordering by owner or by change time fetches it whether or not
+the column is on screen.
+
+A directory's time is Ceph's `rctime`: the newest ctime anywhere beneath it, its own
+included, so changing only its permissions moves it. It is a propagated value that
+starts at zero — creating a directory does not give it one — so a directory nothing
+has happened in since it was made shows the epoch, the usual way a Unix timestamp
+says it was never set. `ls -l` shows a date there instead, because it shows the
+directory's *own* mtime, which creation does set. Creating something inside a
+directory does set the parent's, so only the leaves of a fresh tree read the epoch.
+
 ### Reading the border
 The top border shows the current path on the left and the directory's totals on
 the right. A path too long for the border loses its start, marked with `…`, so
@@ -126,7 +165,7 @@ interface, with the same units the interface uses:
 
 `--parseable` prints the same listing as raw values instead, one row of six
 tab-separated fields per entry — size in bytes, recursive entry count,
-modification time in Unix seconds, user, group, and name — with `-` for anything
+change time in Unix seconds, user, group, and name — with `-` for anything
 the filesystem doesn't provide (recursive values are only available on Ceph).
 Directory names keep their trailing `/`, and `..` is not listed. Symlinks are *not*
 marked here: a filename may contain `@`, so a parser could not tell a mark from a
@@ -159,6 +198,9 @@ cargo test
 The tests in `tests/ceph.rs` cover the recursive xattrs, so they need a CephFS
 mount and skip themselves when there isn't one. They put a scratch tree in
 `/mnt/ceph/users/$USER` by default; set `CEPHDU_TEST_DIR` to use somewhere else.
+
+`tests/syscalls.rs` counts how many syscalls a listing costs, using `strace`, and
+skips without it. `cargo test -- --nocapture` prints the table.
 
 ## Availability on Flatiron Institute Clusters
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Options:
   -d, --dirs-first  List directories before files
   -e, --exact       Show sizes and counts in full instead of scaled to a unit
   -l, --long        Show the owner and directory times, which cost extra syscalls. Implies -f
+  -i, --info        Open the interactive interface with the info panel shown
   -h, --help        Print help
 ```
 
@@ -143,6 +144,31 @@ has happened in since it was made shows the epoch, the usual way a Unix timestam
 says it was never set. `ls -l` shows a date there instead, because it shows the
 directory's *own* mtime, which creation does set. Creating something inside a
 directory does set the parent's, so only the leaves of a fresh tree read the epoch.
+
+### Directory info
+Every number in the listing is recursive, so the non-recursive ones live in a
+panel that `i` toggles under the listing, labeled in words:
+
+```
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+┃            Recursive size:  154.0 TB                                     ┃
+┃         Recursive entries:  4.4 M (4.1 M files, 325.9 K dirs)            ┃
+┃  Recursive mean file size:  37.5 MB                                      ┃
+┃ Recursive entries per dir:  13.5                                         ┃
+┃        Size at this level:  1.1 GB (0.0% of recursive)                   ┃
+┃     Entries at this level:  230 (10 files, 220 dirs, 0.0% of recursive)  ┃
+┗ size ↓ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Press ? for help ┛
+```
+
+"At this level" means the files directly in this directory, the way `du -S`
+counts — so that line answers whether the usage is here or somewhere below. The
+panel follows you as you navigate, and `-i` opens the interface with it shown. Its this-level numbers come from the listing
+already in hand; the recursive ones are read from the directory's own attributes
+when the panel opens or the directory changes, four reads in all, so it costs
+nothing per entry. Off Ceph the recursive lines are absent. The recursive lines
+are a consistent snapshot, which can disagree slightly with the border's totals
+while Ceph is still propagating recent changes; each number is individually
+true.
 
 ### Reading the border
 The top border shows the current path on the left and the directory's totals on

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ CEPHDU_DEFAULT_DIR=/mnt/ceph/users/\$USER cargo build --release
 ```
 The literal string `$USER` is substituted at runtime.
 
+At runtime, the `CEPHDU_DEFAULT_DIR` environment variable overrides the baked-in
+value, with the same `$USER` substitution — so a site can set the default per
+cluster, in a modulefile for example, instead of per build. Setting it to the
+empty string disables the baked-in default too. Either default applies only when
+no path is given and the current directory is not on Ceph; a Ceph current
+directory always wins.
+
 To build a static executable:
 ```console
 cargo build --release cargo build --target=x86_64-unknown-linux-musl
@@ -42,7 +49,10 @@ cargo build --release cargo build --target=x86_64-unknown-linux-musl
 ## Usage
 Simply run `cephdu` from the command line and an interactive terminal user interface (TUI) will be displayed. Navigate using the arrow keys and Enter. For a full list of keyboard shortcuts, press `?`.
 
-The CLI accepts one optional argument, the initial directory:
+The CLI accepts one optional argument, the initial directory. Without it, cephdu
+starts in the current directory if that is on Ceph, and otherwise in
+`$CEPHDU_DEFAULT_DIR` if it is set (see [Installation](#installation) for the
+resolution order):
 ```console
 ❯ cephdu -h
 Display ceph space and file count (inode) usage in an interactive terminal

--- a/README.md
+++ b/README.md
@@ -53,16 +53,17 @@ Arguments:
   [PATH]  Path to the directory to display
 
 Options:
-  -f, --flat       Print a flat text listing, with units, instead of the interactive interface
-  -p, --parseable  Print a flat text listing of raw values, for parsing
-      --tui        Use the interactive interface even if stdout is not a terminal
-  -n, --name       Sort by name
-  -s, --size       Sort by size
-  -c, --count      Sort by file count
-  -u, --owner      Sort by owner
-  -t, --time       Sort by modification time
-  -r, --reverse    Reverse the sort order
-  -h, --help       Print help
+  -f, --flat        Print a flat text listing, with units, instead of the interactive interface
+  -p, --parseable   Print a flat text listing of raw values, for parsing
+      --tui         Use the interactive interface even if stdout is not a terminal
+  -n, --name        Sort by name
+  -s, --size        Sort by size
+  -c, --count       Sort by file count
+  -u, --owner       Sort by owner
+  -t, --time        Sort by modification time
+  -r, --reverse     Reverse the sort order
+  -d, --dirs-first  List directories before files
+  -h, --help        Print help
 ```
 
 ### Sorting
@@ -74,6 +75,9 @@ read ascending. In the interface, pressing the field's key reverses it from ther
 
 `-r` reverses whichever order is in effect and combines with the field flags, so
 `cephdu -r` reads smallest first and `cephdu -nr` reverses the name order.
+
+`-d` groups directories ahead of files, whatever the field and direction, sorting
+within each group by the usual rules. In the interactive interface, `d` toggles it.
 
 ## Flat text mode
 `cephdu --flat` prints the listing as text instead of drawing the interactive

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Simply run `cephdu` from the command line and an interactive terminal user inter
 
 The CLI accepts one optional argument, the initial directory:
 ```console
-❯ cephdu --help
+❯ cephdu -h
 Display ceph space and file count (inode) usage in an interactive terminal
 
 Usage: cephdu [OPTIONS] [PATH]
@@ -87,6 +87,13 @@ always exact, so `-e` has no effect there.
 The bottom border of the interface names the sort in effect, as in `size ↓` for
 largest first or `name ↑` for A to Z, and appends `· dirs first` while directories
 are being grouped.
+
+### Colors
+The interface names as few colors as it can, inheriting the terminal's own, so it
+suits a light terminal as well as a dark one without being told which it is. The
+colors it does name are the row the cursor is on, and red and yellow for errors and
+warnings. The bars keep the terminal's own color on every row, cursor included, so
+the column reads as one chart. Flat listings are never colored.
 
 ### Reading the border
 The top border shows the current path on the left and the directory's totals on

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ read ascending. In the interface, pressing the field's key reverses it from ther
 `-d` groups directories ahead of files, whatever the field and direction, sorting
 within each group by the usual rules. In the interactive interface, `d` toggles it.
 
+The bottom border of the interface names the sort in effect, as in `size ↓` for
+largest first or `name ↑` for A to Z, and appends `· dirs first` while directories
+are being grouped.
+
 ## Flat text mode
 `cephdu --flat` prints the listing as text instead of drawing the interactive
 interface, with the same units the interface uses:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Options:
   -t, --time        Sort by modification time
   -r, --reverse     Reverse the sort order
   -d, --dirs-first  List directories before files
+  -e, --exact       Show sizes and counts in full instead of scaled to a unit
   -h, --help        Print help
 ```
 
@@ -78,6 +79,10 @@ read ascending. In the interface, pressing the field's key reverses it from ther
 
 `-d` groups directories ahead of files, whatever the field and direction, sorting
 within each group by the usual rules. In the interactive interface, `d` toggles it.
+
+`-e` prints sizes and counts in full instead of scaled to a unit, which is useful
+when the rounding matters; `e` toggles it in the interface. The parseable format is
+always exact, so `-e` has no effect there.
 
 The bottom border of the interface names the sort in effect, as in `size ↓` for
 largest first or `name ↑` for A to Z, and appends `· dirs first` while directories

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,6 +25,9 @@ pub struct App {
     pub show_ctime: bool,
     /// Show sizes and counts in full instead of scaled to a unit.
     pub exact: bool,
+    /// Columns scrolled off the left of the listing. Clamped when rendered, since
+    /// only the renderer knows how wide the rows came out.
+    pub hscroll: usize,
     pub message: Option<Message>,
     highlighted: HashMap<PathBuf, (String, usize)>,
 }
@@ -219,6 +222,7 @@ impl App {
             show_owner: false,
             show_ctime: false,
             exact: false,
+            hscroll: 0,
             message: None,
             highlighted: HashMap::new(),
         };

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,6 +32,11 @@ pub struct Options {
     /// on ten thousand directories. A file's time comes from the stat it needs
     /// anyway, so this only concerns directories.
     pub times: bool,
+    /// How many entries' metadata to read at once. On Ceph every read is a
+    /// round trip to the metadata server, so a large listing is latency-bound
+    /// and reads in flight together buy nearly linear speedup. 1 means read
+    /// one at a time, exactly as a listing always has.
+    pub jobs: usize,
 }
 
 impl Options {
@@ -52,6 +57,7 @@ impl Default for Options {
             dirs_first: false,
             owners: false,
             times: false,
+            jobs: 1,
         }
     }
 }
@@ -959,45 +965,139 @@ fn ls(
     if let Some(total) = get_entries(path) {
         watch.set_total(total);
     }
-    let dir_iterator = fs::read_dir(path)?;
+    let mut dents = fs::read_dir(path)?;
     let mut entries: Vec<DirEntry> = Vec::new();
 
-    for entry_result in dir_iterator {
-        // An atomic load, so unlike a syscall it costs a large directory nothing.
-        if watch.cancelled() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Interrupted,
-                "cancelled",
-            ));
+    if options.jobs <= 1 {
+        for entry_result in dents {
+            // An atomic load, so unlike a syscall it costs a large directory nothing.
+            if watch.cancelled() {
+                return Err(interrupted());
+            }
+
+            entries.push(read_entry(&entry_result?, options)?);
+            watch.saw_one();
         }
-
-        let entry = entry_result?;
-        let path = entry.path();
-
-        // readdir already reported the type, so file_type() only falls back to a
-        // stat of its own where the filesystem returned DT_UNKNOWN.
-        let file_type = entry.file_type()?;
-        let kind = if file_type.is_dir() {
-            EntryKind::Dir
-        } else if file_type.is_symlink() {
-            EntryKind::Symlink
-        } else {
-            EntryKind::File
-        };
-
-        // A file's size and time are the stat's alone; a directory needs one only to
-        // say who owns it.
-        let stat = if kind == EntryKind::Dir && !options.owners {
-            None
-        } else {
-            Some(entry.metadata()?)
-        };
-
-        entries.push(DirEntry::from(path, kind, stat, options));
-        watch.saw_one();
+    } else {
+        read_streamed(&mut dents, options, watch, &mut entries)?;
     }
 
     Ok((entry_cwd, entries))
+}
+
+fn interrupted() -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::Interrupted, "cancelled")
+}
+
+/// The per-entry syscalls for one dent.
+fn read_entry(entry: &fs::DirEntry, options: &Options) -> Result<DirEntry, std::io::Error> {
+    let path = entry.path();
+
+    // readdir already reported the type, so file_type() only falls back to a
+    // stat of its own where the filesystem returned DT_UNKNOWN.
+    let file_type = entry.file_type()?;
+    let kind = if file_type.is_dir() {
+        EntryKind::Dir
+    } else if file_type.is_symlink() {
+        EntryKind::Symlink
+    } else {
+        EntryKind::File
+    };
+
+    // A file's size and time are the stat's alone; a directory needs one only to
+    // say who owns it.
+    let stat = if kind == EntryKind::Dir && !options.owners {
+        None
+    } else {
+        Some(entry.metadata()?)
+    };
+
+    Ok(DirEntry::from(path, kind, stat, options))
+}
+
+/// `ls`'s loop with the per-entry syscalls fanned out over `options.jobs`
+/// threads, fed from the readdir through a *bounded* channel. The bound is the
+/// point: it keeps the readdir just ahead of the reads it prefetches for --
+/// draining it first would let the prefetch expire on a directory large enough
+/// for any of this to matter -- while still overlapping it with the workers,
+/// which is worth having because on Ceph the readdir itself is a substantial
+/// serial cost (readdirplus instantiates every child inode: measured 7.5s of a
+/// 33s listing of ten thousand directories).
+fn read_streamed(
+    dents: &mut fs::ReadDir,
+    options: &Options,
+    watch: &ListingWatch,
+    entries: &mut Vec<DirEntry>,
+) -> Result<(), std::io::Error> {
+    let (feed, next) = std::sync::mpsc::sync_channel::<fs::DirEntry>(options.jobs * 4);
+    let next = std::sync::Mutex::new(next);
+    let read = std::sync::Mutex::new((Vec::new(), None::<std::io::Error>));
+
+    std::thread::scope(|s| {
+        for _ in 0..options.jobs {
+            s.spawn(|| {
+                let mut mine: Vec<DirEntry> = Vec::new();
+                loop {
+                    // Even once cancelled or failed, keep receiving: the feeder
+                    // blocks when the channel is full, so every worker must
+                    // drain it to closure or the feeder could never finish.
+                    let Ok(entry) = next.lock().unwrap().recv() else {
+                        break;
+                    };
+                    if watch.cancelled() {
+                        continue;
+                    }
+                    match read_entry(&entry, options) {
+                        Ok(entry) => {
+                            mine.push(entry);
+                            watch.saw_one();
+                        }
+                        Err(e) => {
+                            // First error wins; cancelling stops the rest.
+                            let failed = &mut read.lock().unwrap().1;
+                            if failed.is_none() {
+                                *failed = Some(e);
+                            }
+                            watch.cancel();
+                        }
+                    }
+                }
+                read.lock().unwrap().0.append(&mut mine);
+            });
+        }
+
+        // This thread feeds; `feed` drops at scope end, which is what tells the
+        // workers the listing is over.
+        for entry_result in dents.by_ref() {
+            if watch.cancelled() {
+                break;
+            }
+            let entry = match entry_result {
+                Ok(entry) => entry,
+                Err(e) => {
+                    let failed = &mut read.lock().unwrap().1;
+                    if failed.is_none() {
+                        *failed = Some(e);
+                    }
+                    break;
+                }
+            };
+            if feed.send(entry).is_err() {
+                break;
+            }
+        }
+        drop(feed);
+    });
+
+    let (mut done, failed) = read.into_inner().unwrap();
+    if let Some(e) = failed {
+        return Err(e);
+    }
+    if watch.cancelled() {
+        return Err(interrupted());
+    }
+    entries.append(&mut done);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1670,6 +1770,35 @@ mod tests {
         watch.set_total(10_000);
         let text = app.progress().unwrap().text;
         assert!(text.contains("2 / 10000 entries"), "{}", text);
+    }
+
+    /// Concurrency is a speed choice, never a content one. Compared under a name
+    /// sort because a size order isn't stable between two reads on Ceph, where
+    /// recursive sizes settle asynchronously; file sizes are stat's and stable.
+    #[test]
+    fn concurrent_reads_list_the_same_entries() {
+        let options = Options::sorted(SortMode::Normal(SortField::Name));
+        let sequential = DirListing::from(Path::new("."), options).unwrap();
+        let concurrent = DirListing::from(Path::new("."), Options { jobs: 5, ..options }).unwrap();
+
+        let names = |l: &DirListing| l.iter_entries().map(|e| e.name.clone()).collect::<Vec<_>>();
+        assert!(sequential.len() > 1, "nothing listed to compare");
+        assert_eq!(names(&sequential), names(&concurrent));
+
+        let file_sizes = |l: &DirListing| {
+            l.iter_entries()
+                .filter(|e| e.kind == EntryKind::File)
+                .map(|e| (e.name.clone(), e.size))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(file_sizes(&sequential), file_sizes(&concurrent));
+
+        // Errors surface just as they do one at a time.
+        let missing = DirListing::from(
+            Path::new("does_not_exist_xyz"),
+            Options { jobs: 5, ..options },
+        );
+        assert!(missing.is_err());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,12 +2,13 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fs::Metadata;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
+use std::time::{Duration, Instant};
 use std::{fs, os::unix::fs::MetadataExt};
 
-use crossterm::event::{self, Event, KeyCode, KeyModifiers, poll};
-
 use ratatui::widgets::ListState;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 use crate::fs::{FSType, get_fs, get_rbytes, get_rctime, get_rentries, id_to_name};
 use crate::navigation;
@@ -59,7 +60,8 @@ pub struct App {
     pub should_exit: bool,
     pub cwd: PathBuf,
     pub dir_listing: DirListing,
-    pub original_cwd: PathBuf,
+    /// Where the app started, once the first listing has resolved it.
+    pub original_cwd: Option<PathBuf>,
     pub popup: Option<Popup>,
     pub show_owner: bool,
     pub show_ctime: bool,
@@ -70,7 +72,81 @@ pub struct App {
     pub hscroll: usize,
     pub message: Option<Message>,
     highlighted: HashMap<PathBuf, (String, usize)>,
+    /// Cloned into each listing worker; results come back through the paired
+    /// receiver, which the event loop owns.
+    tx: UnboundedSender<ListingMsg>,
+    pending: Option<Pending>,
+    /// Numbers the listing requests so that an answer to a superseded one -- the
+    /// worker keeps running until it next checks its watch -- is recognized on
+    /// arrival and dropped.
+    generation: u64,
 }
+
+/// Shared between a listing worker and the interface. Plain atomics rather than
+/// anything async, so the worker stays ordinary blocking code: it checks `cancel`
+/// between entries and counts into `seen`, and either side can be polled cheaply.
+pub struct ListingWatch {
+    cancel: AtomicBool,
+    seen: AtomicUsize,
+}
+
+impl ListingWatch {
+    fn new() -> ListingWatch {
+        ListingWatch {
+            cancel: AtomicBool::new(false),
+            seen: AtomicUsize::new(0),
+        }
+    }
+
+    fn cancel(&self) {
+        self.cancel.store(true, AtomicOrdering::Relaxed);
+    }
+
+    fn cancelled(&self) -> bool {
+        self.cancel.load(AtomicOrdering::Relaxed)
+    }
+
+    fn saw_one(&self) {
+        self.seen.fetch_add(1, AtomicOrdering::Relaxed);
+    }
+
+    fn seen(&self) -> usize {
+        self.seen.load(AtomicOrdering::Relaxed)
+    }
+}
+
+/// A listing worker's answer. `generation` says which request it answers.
+pub struct ListingMsg {
+    generation: u64,
+    result: Result<(PathBuf, DirListing), std::io::Error>,
+}
+
+/// A listing not yet arrived: the request's identity, its watch, and what to do if
+/// it fails.
+struct Pending {
+    generation: u64,
+    /// As requested, for the progress notice; the canonical path arrives with the
+    /// listing.
+    path: PathBuf,
+    watch: Arc<ListingWatch>,
+    started: Instant,
+    on_error: OnError,
+    /// Leave whatever message is already on screen alone when this listing lands.
+    /// The fallback dispatch sets a warning that landing must not clear.
+    preserve_message: bool,
+}
+
+/// What to do when a listing fails to read.
+pub enum OnError {
+    /// Show the error and stay where we are.
+    Message,
+    /// Try this path instead -- the startup fallback -- warning first if asked to.
+    Fallback { path: PathBuf, warn: bool },
+}
+
+/// How long a read may run before the interface mentions it. Long enough that an
+/// ordinary directory change never flashes the notice.
+const PROGRESS_AFTER: Duration = Duration::from_millis(150);
 
 /// An encapsulation of a list of all files/dirs in a directory.
 pub struct DirListing {
@@ -252,20 +328,16 @@ pub enum MessageKind {
 }
 
 impl App {
-    pub fn new(cwd: Option<&PathBuf>, options: Options) -> Result<App, std::io::Error> {
-        let cwd: PathBuf = if let Some(cwd) = cwd {
-            cwd.clone()
-        } else {
-            std::env::current_dir()?
-        };
-
-        let dir_listing = DirListing::empty(options);
-        let original_cwd = cwd.clone();
-        let mut app = App {
+    /// An app with nothing listed yet. Reads are dispatched with `start_listing`
+    /// and land through the returned receiver, so nothing here touches the
+    /// filesystem and the interface can draw before the first listing arrives.
+    pub fn new(options: Options) -> (App, UnboundedReceiver<ListingMsg>) {
+        let (tx, rx) = unbounded_channel();
+        let app = App {
             should_exit: false,
             cwd: PathBuf::new(),
-            dir_listing,
-            original_cwd,
+            dir_listing: DirListing::empty(options),
+            original_cwd: None,
             popup: None,
             show_owner: false,
             show_ctime: false,
@@ -273,52 +345,154 @@ impl App {
             hscroll: 0,
             message: None,
             highlighted: HashMap::new(),
+            tx,
+            pending: None,
+            generation: 0,
         };
-        app.try_cd(&cwd)?;
-
-        // Save the original (resolved) dir
-        app.original_cwd = app.cwd.clone();
-
-        Ok(app)
+        (app, rx)
     }
 
     pub fn cd(&mut self, path: &PathBuf) {
-        let res = self.try_cd(path);
-        if let Err(e) = res {
+        let target = if path.is_absolute() {
+            path.clone()
+        } else {
+            self.cwd.join(path)
+        };
+        self.start_listing(target, OnError::Message, false);
+    }
+
+    /// Read `path` on a worker thread; the result arrives as a `ListingMsg`. Any
+    /// read already in flight is superseded: told to stop, and its answer dropped
+    /// if it lands anyway. The worker is a plain thread rather than a runtime task
+    /// so that one blocked in a syscall can never stall anything else -- quitting
+    /// included -- and so this needs no runtime to be running.
+    pub fn start_listing(&mut self, path: PathBuf, on_error: OnError, preserve_message: bool) {
+        if let Some(old) = self.pending.take() {
+            old.watch.cancel();
+        }
+        self.generation += 1;
+        let generation = self.generation;
+        let watch = Arc::new(ListingWatch::new());
+        // What the read fetches follows the columns and sort, not what the current
+        // listing happened to be read with: leaving a directory with the owner
+        // hidden should not make the next one pay for it.
+        let options = self.needs();
+
+        let tx = self.tx.clone();
+        let worker = {
+            let path = path.clone();
+            let watch = watch.clone();
+            move || {
+                let result = path.canonicalize().and_then(|canon| {
+                    DirListing::from_watched(&canon, options, &watch).map(|l| (canon, l))
+                });
+                // The receiver is gone only when the app is; nowhere to report to.
+                let _ = tx.send(ListingMsg { generation, result });
+            }
+        };
+        std::thread::spawn(worker);
+
+        self.pending = Some(Pending {
+            generation,
+            path,
+            watch,
+            started: Instant::now(),
+            on_error,
+            preserve_message,
+        });
+    }
+
+    /// Apply a worker's answer, unless it answers a request that is no longer the
+    /// live one -- superseded or cancelled -- in which case it is dropped.
+    pub fn on_listing_msg(&mut self, msg: ListingMsg) {
+        if self.pending.as_ref().map(|p| p.generation) != Some(msg.generation) {
+            return;
+        }
+        let pending = self.pending.take().unwrap();
+
+        match msg.result {
+            Ok((path, listing)) => {
+                // Record which entry was highlighted in case we navigate back.
+                // Saved now, not at dispatch, so moving the cursor while the read
+                // ran isn't undone.
+                self.save_selected();
+                self.dir_listing = listing;
+                self.cwd = path;
+                if self.original_cwd.is_none() {
+                    self.original_cwd = Some(self.cwd.clone());
+                }
+                if !pending.preserve_message {
+                    if !self.dir_listing.is_ceph() {
+                        self.message(Some(Message {
+                            text: "Warning: not a Ceph directory".to_string(),
+                            kind: MessageKind::Warning,
+                        }));
+                    } else {
+                        self.message(None);
+                    }
+                }
+                // Restore the highlighted entry if we have one
+                self.restore_selected();
+                // A column toggled or a sort begun while the read ran may need
+                // more than it fetched.
+                self.fetch_if_needed();
+            }
+            Err(e) => match pending.on_error {
+                OnError::Message => self.message(Some(Message {
+                    text: format!("Error changing directory: {}", e),
+                    kind: MessageKind::Error,
+                })),
+                OnError::Fallback { path, warn } => {
+                    if warn {
+                        self.message(Some(Message {
+                            text: format!("Error opening {:?}: {}", pending.path, e),
+                            kind: MessageKind::Warning,
+                        }));
+                    }
+                    self.start_listing(path, OnError::Message, warn);
+                }
+            },
+        }
+    }
+
+    /// Stop the read in flight, staying in the directory on screen. The worker
+    /// exits when it next checks; its answer is already orphaned here.
+    pub fn cancel_listing(&mut self) {
+        if let Some(pending) = self.pending.take() {
+            pending.watch.cancel();
             self.message(Some(Message {
-                text: format!("Error changing directory: {}", e),
-                kind: MessageKind::Error,
+                text: format!("Cancelled reading {:?}", pending.path),
+                kind: MessageKind::Warning,
             }));
         }
     }
 
-    fn try_cd(&mut self, path: &PathBuf) -> Result<(), std::io::Error> {
-        // Record which entry was highlighted in case we navigate back
-        self.save_selected();
+    pub fn is_reading(&self) -> bool {
+        self.pending.is_some()
+    }
 
-        let new = if path.is_absolute() {
-            path.canonicalize()?
-        } else {
-            self.cwd.join(path).canonicalize()?
-        };
-        // What the next read fetches follows the column, not what this listing
-        // happened to be read with: leaving a directory with the owner hidden should
-        // not make the next one pay for it.
-        let options = self.needs();
-        self.dir_listing = DirListing::from(&new, options)?;
-        self.cwd = new;
-        if !self.dir_listing.is_ceph() {
-            self.message(Some(Message {
-                text: "Warning: not a Ceph directory".to_string(),
-                kind: MessageKind::Warning,
-            }));
-        } else {
-            self.message(None);
+    /// Block until nothing is in flight, applying each answer as it lands: what the
+    /// event loop does, for tests -- which therefore exercise the real dispatch.
+    #[cfg(test)]
+    pub fn pump(&mut self, listings: &mut UnboundedReceiver<ListingMsg>) {
+        while self.pending.is_some() {
+            let msg = listings.blocking_recv().expect("listing worker hung up");
+            self.on_listing_msg(msg);
         }
+    }
 
-        // Restore the highlighted entry if we have one
-        self.restore_selected();
-        Ok(())
+    /// The notice for a read still running, once it has been slow enough to
+    /// mention -- an ordinary directory change comes and goes without one.
+    pub fn progress(&self) -> Option<Message> {
+        let pending = self.pending.as_ref()?;
+        (pending.started.elapsed() >= PROGRESS_AFTER).then(|| Message {
+            text: format!(
+                "Reading {:?} ... {} entries (Ctrl-C to cancel)",
+                pending.path,
+                pending.watch.seen()
+            ),
+            kind: MessageKind::Info,
+        })
     }
 
     /// What a read of this directory would have to fetch: a column needs its value,
@@ -428,10 +602,21 @@ impl App {
 
 impl DirListing {
     pub fn from(path: &Path, options: Options) -> Result<DirListing, std::io::Error> {
+        // A watch nothing holds: never cancelled, progress unread.
+        DirListing::from_watched(path, options, &ListingWatch::new())
+    }
+
+    /// `from`, reporting to a watch: the read stops (with `ErrorKind::Interrupted`)
+    /// when the watch is cancelled, and counts entries into it as they land.
+    fn from_watched(
+        path: &Path,
+        options: Options,
+        watch: &ListingWatch,
+    ) -> Result<DirListing, std::io::Error> {
         let path: PathBuf = path.canonicalize()?;
         let fs = get_fs(&path);
 
-        let (entry_cwd, mut entries): (DirEntry, Vec<DirEntry>) = ls(&path, &options)?;
+        let (entry_cwd, mut entries): (DirEntry, Vec<DirEntry>) = ls(&path, &options, watch)?;
 
         // Don't trust dir sizes on non-ceph!
         if !fs.map(FSType::is_ceph).unwrap_or(false) {
@@ -739,7 +924,11 @@ fn sort(entries: &mut [DirEntry], sort_mode: SortMode, dirs_first: bool) {
     });
 }
 
-fn ls(path: &PathBuf, options: &Options) -> Result<(DirEntry, Vec<DirEntry>), std::io::Error> {
+fn ls(
+    path: &PathBuf,
+    options: &Options,
+    watch: &ListingWatch,
+) -> Result<(DirEntry, Vec<DirEntry>), std::io::Error> {
     // The cwd is only here for its totals, so it needs neither a stat nor a time.
     let totals = Options {
         owners: false,
@@ -751,20 +940,12 @@ fn ls(path: &PathBuf, options: &Options) -> Result<(DirEntry, Vec<DirEntry>), st
     let mut entries: Vec<DirEntry> = Vec::new();
 
     for entry_result in dir_iterator {
-        if poll(Duration::from_secs(0)).unwrap_or(false) {
-            // If the user presses Ctrl-C during this loop, interrupt.
-            // TODO: this is the wrong way to do this! The whole app should use an
-            // async runtime that can handle key presses and interrupts.
-
-            if let Ok(Event::Key(key)) = event::read()
-                && key.code == KeyCode::Char('c')
-                && key.modifiers.contains(KeyModifiers::CONTROL)
-            {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Interrupted,
-                    "Interrupted by user",
-                ));
-            }
+        // An atomic load, so unlike a syscall it costs a large directory nothing.
+        if watch.cancelled() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "cancelled",
+            ));
         }
 
         let entry = entry_result?;
@@ -790,6 +971,7 @@ fn ls(path: &PathBuf, options: &Options) -> Result<(DirEntry, Vec<DirEntry>), st
         };
 
         entries.push(DirEntry::from(path, kind, stat, options));
+        watch.saw_one();
     }
 
     Ok((entry_cwd, entries))
@@ -798,6 +980,16 @@ fn ls(path: &PathBuf, options: &Options) -> Result<(DirEntry, Vec<DirEntry>), st
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An app listing `path`, read to completion the way the event loop would.
+    /// Keep the receiver: every later call that can dispatch a read -- cd, the
+    /// toggles, the sorts -- needs a `pump` after it.
+    fn app_at(path: &str, options: Options) -> (App, UnboundedReceiver<ListingMsg>) {
+        let (mut app, mut listings) = App::new(options);
+        app.start_listing(PathBuf::from(path), OnError::Message, false);
+        app.pump(&mut listings);
+        (app, listings)
+    }
 
     fn entry(name: &str, size: usize) -> DirEntry {
         DirEntry {
@@ -1003,7 +1195,7 @@ mod tests {
     /// highlighted there. Uses the crate's own tree, which cargo makes the cwd.
     #[test]
     fn cd_selects_the_first_real_entry_then_remembers() {
-        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+        let (mut app, mut listings) = app_at(".", Options::default());
         assert_eq!(app.dir_listing.selected(), Some(1));
         assert_ne!(app.dir_listing.get(1).name, "..");
 
@@ -1011,9 +1203,11 @@ mod tests {
             .select_by_name("src/")
             .expect("src/ should be listed");
         app.cd(&PathBuf::from("src"));
+        app.pump(&mut listings);
         assert_eq!(app.dir_listing.selected(), Some(1), "did not skip '..'");
 
         app.cd(&PathBuf::from(".."));
+        app.pump(&mut listings);
         let selected = app.dir_listing.selected().unwrap();
         assert_eq!(app.dir_listing.get(selected).name, "src/");
     }
@@ -1046,7 +1240,7 @@ mod tests {
     /// for -- which is also what lets a directory be listed without a stat at all.
     #[test]
     fn the_owner_is_read_only_when_asked_for() {
-        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+        let (mut app, mut listings) = app_at(".", Options::default());
         assert!(!app.dir_listing.options().owners);
         assert!(
             app.dir_listing
@@ -1056,6 +1250,7 @@ mod tests {
         );
 
         app.toggle_owner();
+        app.pump(&mut listings);
         assert!(app.show_owner);
         assert!(app.dir_listing.options().owners);
         assert!(
@@ -1088,7 +1283,7 @@ mod tests {
     /// somewhere else: the xattrs, and readdir for the kind.
     #[test]
     fn a_directory_needs_no_stat() {
-        let app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+        let (app, _listings) = app_at(".", Options::default());
 
         let dirs: Vec<&DirEntry> = app
             .dir_listing
@@ -1111,8 +1306,9 @@ mod tests {
     /// not pay for it twice, however many times it is toggled.
     #[test]
     fn showing_the_owner_again_does_not_re_read_it() {
-        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+        let (mut app, mut listings) = app_at(".", Options::default());
         app.toggle_owner();
+        app.pump(&mut listings);
         assert!(
             app.dir_listing.options().owners,
             "the first show did not read"
@@ -1121,9 +1317,13 @@ mod tests {
         // A value only a re-read would overwrite.
         app.dir_listing.entries[0].user = Some("sentinel".to_string());
 
+        // Pumped each time, so a wrongly dispatched re-read would actually land
+        // and clobber the sentinel rather than sit unapplied in the channel.
         for _ in 0..3 {
             app.toggle_owner();
+            app.pump(&mut listings);
             app.toggle_owner();
+            app.pump(&mut listings);
         }
 
         assert!(app.show_owner);
@@ -1138,16 +1338,19 @@ mod tests {
     /// owner, and leaving with it shown should.
     #[test]
     fn the_next_directory_follows_the_column() {
-        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+        let (mut app, mut listings) = app_at(".", Options::default());
 
         app.cd(&PathBuf::from("src"));
+        app.pump(&mut listings);
         assert!(
             !app.dir_listing.options().owners,
             "read the owner with the column hidden"
         );
 
         app.toggle_owner();
+        app.pump(&mut listings);
         app.cd(&PathBuf::from(".."));
+        app.pump(&mut listings);
         assert!(
             app.dir_listing.options().owners,
             "did not read the owner with the column shown"
@@ -1164,10 +1367,11 @@ mod tests {
     /// Without this the sort silently had nothing to compare.
     #[test]
     fn sorting_by_owner_reads_the_owner() {
-        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+        let (mut app, mut listings) = app_at(".", Options::default());
         assert!(!app.dir_listing.options().owners);
 
         app.sort_or_reverse(SortField::Owner.default_mode());
+        app.pump(&mut listings);
         assert!(
             app.dir_listing.options().owners,
             "sorted by an owner that was never read"
@@ -1184,6 +1388,7 @@ mod tests {
         // hidden: the next directory has to sort by it too.
         assert!(!app.show_owner);
         app.cd(&PathBuf::from("src"));
+        app.pump(&mut listings);
         assert!(
             app.dir_listing.options().owners,
             "the next directory sorted by an owner it never read"
@@ -1195,10 +1400,11 @@ mod tests {
     /// rather than the values, since off Ceph there is no rctime to find.
     #[test]
     fn showing_the_time_reads_it_once() {
-        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+        let (mut app, mut listings) = app_at(".", Options::default());
         assert!(!app.dir_listing.options().times);
 
         app.toggle_ctime();
+        app.pump(&mut listings);
         assert!(app.show_ctime);
         assert!(
             app.dir_listing.options().times,
@@ -1209,7 +1415,9 @@ mod tests {
         app.dir_listing.entries[0].ctime = Some(12_345);
         for _ in 0..3 {
             app.toggle_ctime();
+            app.pump(&mut listings);
             app.toggle_ctime();
+            app.pump(&mut listings);
         }
         assert_eq!(
             app.dir_listing.entries[0].ctime,
@@ -1220,9 +1428,10 @@ mod tests {
 
     #[test]
     fn sorting_by_time_reads_it() {
-        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+        let (mut app, mut listings) = app_at(".", Options::default());
 
         app.sort_or_reverse(SortField::CTime.default_mode());
+        app.pump(&mut listings);
         assert!(
             app.dir_listing.options().times,
             "sorted by a time that was never read"
@@ -1263,7 +1472,7 @@ mod tests {
     #[test]
     fn new_honors_the_startup_sort_mode() {
         let mode = SortMode::Normal(SortField::Name);
-        let app = App::new(Some(&PathBuf::from(".")), Options::sorted(mode)).unwrap();
+        let (app, _listings) = app_at(".", Options::sorted(mode));
         assert_eq!(app.dir_listing.sort_mode(), mode);
 
         let names: Vec<String> = app
@@ -1274,6 +1483,139 @@ mod tests {
         let mut ascending = names.clone();
         ascending.sort();
         assert_eq!(names, ascending, "listing is not in name order");
+    }
+
+    /// Cancelling keeps the directory on screen, and the worker's answer -- it may
+    /// well finish anyway, having lost the race to the cancel -- is dropped when it
+    /// lands rather than applied.
+    #[test]
+    fn cancelling_stays_put_and_orphans_the_answer() {
+        let (mut app, mut listings) = app_at(".", Options::default());
+        let before = app.cwd.clone();
+
+        app.cd(&PathBuf::from("src"));
+        assert!(app.is_reading());
+        app.cancel_listing();
+        assert!(!app.is_reading());
+        assert_eq!(app.cwd, before);
+
+        // The answer arrives regardless; feed it through and nothing may change.
+        let msg = listings.blocking_recv().expect("worker never answered");
+        app.on_listing_msg(msg);
+        assert_eq!(app.cwd, before, "a cancelled read was applied");
+    }
+
+    /// A second dispatch supersedes the first: both answers arrive, and only the
+    /// second may apply, whatever order the workers finish in.
+    #[test]
+    fn a_newer_read_supersedes_an_older_one() {
+        let (mut app, mut listings) = app_at(".", Options::default());
+
+        app.cd(&PathBuf::from("src"));
+        app.cd(&PathBuf::from("tests"));
+        app.pump(&mut listings);
+
+        assert_eq!(
+            app.cwd.file_name().unwrap().to_str().unwrap(),
+            "tests",
+            "the superseded read won"
+        );
+    }
+
+    /// The startup fallback: a bad path falls back to the fallback path, and the
+    /// warning that says so survives the fallback listing's arrival.
+    #[test]
+    fn a_failed_first_listing_falls_back_with_its_warning() {
+        let (mut app, mut listings) = App::new(Options::default());
+        app.start_listing(
+            PathBuf::from("does_not_exist_xyz"),
+            OnError::Fallback {
+                path: PathBuf::from("."),
+                warn: true,
+            },
+            false,
+        );
+        app.pump(&mut listings);
+
+        assert_eq!(app.cwd, PathBuf::from(".").canonicalize().unwrap());
+        let message = app.message.as_ref().expect("the warning was cleared");
+        assert!(
+            message.text.contains("does_not_exist_xyz"),
+            "wrong message: {}",
+            message.text
+        );
+        assert_eq!(
+            app.original_cwd.as_ref(),
+            Some(&app.cwd),
+            "the fallback should become the original directory"
+        );
+    }
+
+    /// A failed cd reports and stays put, as it always has.
+    #[test]
+    fn a_failed_cd_keeps_the_old_listing() {
+        let (mut app, mut listings) = app_at(".", Options::default());
+        let before = app.cwd.clone();
+
+        app.cd(&PathBuf::from("does_not_exist_xyz"));
+        app.pump(&mut listings);
+
+        assert_eq!(app.cwd, before);
+        assert!(matches!(
+            app.message.as_ref().map(|m| m.kind),
+            Some(MessageKind::Error)
+        ));
+    }
+
+    /// Esc and Ctrl-C cancel a read; neither quits, and in particular Ctrl-C must
+    /// not fall through to `c`, sort by count. Only q quits: a cancel key that
+    /// doubled as quit would make an extra press -- or one landing just after the
+    /// read finishes -- exit unintended.
+    #[test]
+    fn esc_and_ctrl_c_cancel_and_only_q_quits() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        let (mut app, _listings) = app_at(".", Options::default());
+
+        app.cd(&PathBuf::from("src"));
+        app.handle_key(KeyEvent::from(KeyCode::Esc));
+        assert!(!app.is_reading(), "Esc did not cancel the read");
+        assert!(!app.should_exit, "Esc quit instead of cancelling");
+
+        app.handle_key(KeyEvent::from(KeyCode::Esc));
+        assert!(!app.should_exit, "an idle Esc quit");
+
+        app.cd(&PathBuf::from("src"));
+        app.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        assert!(!app.is_reading(), "Ctrl-C did not cancel the read");
+        assert!(!app.should_exit);
+
+        let sorted_by = *app.dir_listing.sort_mode().field();
+        app.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        assert_eq!(
+            *app.dir_listing.sort_mode().field(),
+            sorted_by,
+            "an idle Ctrl-C fell through to the count sort"
+        );
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('q')));
+        assert!(app.should_exit, "q did not quit");
+    }
+
+    /// The progress notice appears only once a read has been slow enough to
+    /// mention, and goes away with the read.
+    #[test]
+    fn progress_is_mentioned_only_for_a_slow_read() {
+        let (mut app, mut listings) = app_at(".", Options::default());
+
+        app.cd(&PathBuf::from("src"));
+        // Backdate the read instead of sleeping through the threshold.
+        app.pending.as_mut().unwrap().started = Instant::now() - 2 * PROGRESS_AFTER;
+        let notice = app.progress().expect("a slow read went unmentioned");
+        assert!(notice.text.contains("entries"), "{}", notice.text);
+
+        app.pump(&mut listings);
+        assert!(app.progress().is_none(), "the notice outlived the read");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,10 @@ use std::{fs, os::unix::fs::MetadataExt};
 use ratatui::widgets::ListState;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
-use crate::fs::{FSType, get_entries, get_fs, get_rbytes, get_rctime, get_rentries, id_to_name};
+use crate::fs::{
+    FSType, get_entries, get_fs, get_rbytes, get_rctime, get_rentries, get_rfiles, get_rsubdirs,
+    id_to_name,
+};
 use crate::navigation;
 use crate::popup::Popup;
 
@@ -77,6 +80,10 @@ pub struct App {
     /// only the renderer knows how wide the rows came out.
     pub hscroll: usize,
     pub message: Option<Message>,
+    /// The numbers behind the info panel; `Some` is what "shown" means. Cached
+    /// raw rather than formatted so `e` reformats them, and so the panel costs
+    /// its four xattr reads once at the toggle or on arrival, never per frame.
+    pub info: Option<InfoStats>,
     highlighted: HashMap<PathBuf, (String, usize)>,
     /// Cloned into each listing worker; results come back through the paired
     /// receiver, which the event loop owns.
@@ -455,6 +462,20 @@ pub enum MessageKind {
     Info,
 }
 
+/// What the info panel shows, as numbers. This-level values are counted from the
+/// listing's entries; the recursive ones are the cwd's r-attrs, absent off Ceph.
+/// `rentries` and `rsubdirs` already have the directory's self-count removed.
+#[derive(Debug, Clone, Copy)]
+pub struct InfoStats {
+    pub level_bytes: usize,
+    pub level_files: usize,
+    pub level_dirs: usize,
+    pub rbytes: Option<usize>,
+    pub rentries: Option<usize>,
+    pub rfiles: Option<usize>,
+    pub rsubdirs: Option<usize>,
+}
+
 impl App {
     /// An app with nothing listed yet. Reads are dispatched with `start_listing`
     /// and land through the returned receiver, so nothing here touches the
@@ -472,6 +493,7 @@ impl App {
             exact: false,
             hscroll: 0,
             message: None,
+            info: None,
             highlighted: HashMap::new(),
             tx,
             pending: None,
@@ -609,6 +631,10 @@ impl App {
                 }
                 // Restore the highlighted entry if we have one
                 self.restore_selected();
+                // The panel describes whatever is on screen, so it follows.
+                if self.info.is_some() {
+                    self.info = Some(self.compute_info());
+                }
                 // A column toggled or a sort begun while the read ran may need
                 // more than it fetched.
                 self.fetch_if_needed();
@@ -763,6 +789,52 @@ impl App {
             Some(env!("CARGO_PKG_REPOSITORY")),
             Some(&help_text),
         );
+    }
+
+    pub fn toggle_info(&mut self) {
+        self.info = match self.info {
+            Some(_) => None,
+            None => Some(self.compute_info()),
+        };
+    }
+
+    /// The numbers for the info panel (issues #9, #16, #17): what the listing
+    /// cannot show without muddying it, chiefly how much of the usage sits at
+    /// this level in loose files against everything below.
+    ///
+    /// This level comes from the listing in hand -- file sizes and kinds were read
+    /// with it -- so it works on any filesystem. The recursive values are a fresh
+    /// snapshot of the cwd's four r-attrs, read now rather than taken from the
+    /// listing so that they are consistent *with each other*; they may disagree
+    /// transiently with the border's totals (or this level's sums) while the MDS
+    /// propagates, and each is still individually true. Off Ceph they are `None`
+    /// and their lines are simply omitted.
+    fn compute_info(&self) -> InfoStats {
+        let level_bytes: usize = self
+            .dir_listing
+            .entries
+            .iter()
+            .filter(|e| e.kind != EntryKind::Dir)
+            .filter_map(|e| e.size)
+            .sum();
+        let level_files = self
+            .dir_listing
+            .entries
+            .iter()
+            .filter(|e| e.kind != EntryKind::Dir)
+            .count();
+        let level_dirs = self.dir_listing.entries.len() - level_files;
+
+        InfoStats {
+            level_bytes,
+            level_files,
+            level_dirs,
+            rbytes: get_rbytes(&self.cwd),
+            rentries: get_rentries(&self.cwd).map(|n| n.saturating_sub(1)),
+            rfiles: get_rfiles(&self.cwd),
+            // Of the four, only rsubdirs counts the directory itself.
+            rsubdirs: get_rsubdirs(&self.cwd).map(|n| n.saturating_sub(1)),
+        }
     }
 
     pub fn sort_or_reverse(&mut self, sort_mode: SortMode) {
@@ -1938,6 +2010,61 @@ mod tests {
         let mut ascending = names.clone();
         ascending.sort();
         assert_eq!(names, ascending, "listing is not in name order");
+    }
+
+    /// The -i flag's path: the panel opens before anything is listed, and the
+    /// first listing's arrival fills it in.
+    #[test]
+    fn a_panel_opened_at_startup_follows_the_first_listing() {
+        let (mut app, mut listings) = App::new(Options::default());
+        app.toggle_info();
+        assert_eq!(app.info.unwrap().level_files, 0, "nothing is listed yet");
+
+        app.start_listing(PathBuf::from("."), OnError::Message, false);
+        app.pump(&mut listings);
+
+        let stats = app.info.expect("the first listing closed the panel");
+        assert!(stats.level_files > 0, "the arrival did not fill the panel");
+    }
+
+    /// The info panel's this-level numbers come from the listing in hand, its
+    /// recursive ones only from a filesystem that provides them -- and it follows
+    /// a directory change, since it describes whatever is on screen.
+    #[test]
+    fn info_describes_the_current_level() {
+        use crossterm::event::{KeyCode, KeyEvent};
+
+        let (mut app, mut listings) = app_at(".", Options::default());
+        app.handle_key(KeyEvent::from(KeyCode::Char('i')));
+
+        let stats = app.info.expect("i did not open the panel");
+        // The repo has files and directories at its top level.
+        assert!(stats.level_bytes > 0);
+        assert!(stats.level_files > 0);
+        assert!(stats.level_dirs > 0);
+        if app.dir_listing.is_ceph() {
+            assert!(stats.rbytes.is_some());
+            assert!(stats.rfiles.is_some());
+        } else {
+            assert!(stats.rbytes.is_none());
+        }
+
+        // Whatever directory is on screen is the one described.
+        app.cd(&PathBuf::from("src"));
+        app.pump(&mut listings);
+        let stats = app.info.expect("the cd closed the panel");
+        let files_on_screen = app
+            .dir_listing
+            .iter_entries_sorted()
+            .filter(|e| e.kind != EntryKind::Dir)
+            .count();
+        assert_eq!(
+            stats.level_files, files_on_screen,
+            "the panel does not match the listing"
+        );
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('i')));
+        assert!(app.info.is_none(), "i did not close the panel");
     }
 
     /// Cancelling keeps the directory on screen, and the worker's answer -- it may

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fs::Metadata;
 use std::path::{Path, PathBuf};
@@ -32,6 +33,7 @@ pub struct DirListing {
     entries: Vec<DirEntry>,
     state: ListState,
     sort_mode: SortMode,
+    dirs_first: bool,
     pub stats: ListingStats,
     pub fs: Option<FSType>,
 }
@@ -182,14 +184,18 @@ pub enum MessageKind {
 }
 
 impl App {
-    pub fn new(cwd: Option<&PathBuf>, sort_mode: SortMode) -> Result<App, std::io::Error> {
+    pub fn new(
+        cwd: Option<&PathBuf>,
+        sort_mode: SortMode,
+        dirs_first: bool,
+    ) -> Result<App, std::io::Error> {
         let cwd: PathBuf = if let Some(cwd) = cwd {
             cwd.clone()
         } else {
             std::env::current_dir()?
         };
 
-        let dir_listing = DirListing::empty(sort_mode);
+        let dir_listing = DirListing::empty(sort_mode, dirs_first);
         let original_cwd = cwd.clone();
         let mut app = App {
             should_exit: false,
@@ -229,7 +235,11 @@ impl App {
         } else {
             self.cwd.join(path).canonicalize()?
         };
-        self.dir_listing = DirListing::from(&new, self.dir_listing.sort_mode)?;
+        self.dir_listing = DirListing::from(
+            &new,
+            self.dir_listing.sort_mode,
+            self.dir_listing.dirs_first,
+        )?;
         self.cwd = new;
         if !self.dir_listing.is_ceph() {
             self.message(Some(Message {
@@ -316,7 +326,11 @@ impl App {
 }
 
 impl DirListing {
-    pub fn from(path: &Path, sort_mode: SortMode) -> Result<DirListing, std::io::Error> {
+    pub fn from(
+        path: &Path,
+        sort_mode: SortMode,
+        dirs_first: bool,
+    ) -> Result<DirListing, std::io::Error> {
         let path: PathBuf = path.canonicalize()?;
         let fs = get_fs(&path);
 
@@ -331,7 +345,7 @@ impl DirListing {
                     e.size = None;
                 });
         }
-        sort(&mut entries, sort_mode);
+        sort(&mut entries, sort_mode, dirs_first);
 
         let has_parent = *path != *"/";
         let dotdot = has_parent.then(dotdot_entry);
@@ -355,6 +369,7 @@ impl DirListing {
             state,
             dotdot,
             sort_mode,
+            dirs_first,
             stats: ListingStats {
                 max_rentries,
                 total_rentries,
@@ -371,8 +386,9 @@ impl DirListing {
         mut entries: Vec<DirEntry>,
         has_dotdot: bool,
         sort_mode: SortMode,
+        dirs_first: bool,
     ) -> DirListing {
-        sort(&mut entries, sort_mode);
+        sort(&mut entries, sort_mode, dirs_first);
 
         let (max_rentries, max_size) = max_stats(&entries);
 
@@ -387,16 +403,18 @@ impl DirListing {
             entries,
             state: ListState::default().with_selected(Some(0)),
             sort_mode,
+            dirs_first,
             fs: None,
         }
     }
 
-    fn empty(sort_mode: SortMode) -> DirListing {
+    fn empty(sort_mode: SortMode, dirs_first: bool) -> DirListing {
         DirListing {
             dotdot: None,
             entries: Vec::new(),
             state: ListState::default(),
             sort_mode,
+            dirs_first,
             stats: ListingStats {
                 max_rentries: 0,
                 total_rentries: 0,
@@ -536,14 +554,21 @@ impl DirListing {
     }
 
     pub fn sort(&mut self, sort_mode: SortMode) {
-        if self.sort_mode.same_field(&sort_mode) {
+        // Reversing normally needs no re-sort, but with dirs_first the stored order
+        // depends on the direction, so only the plain case can short-circuit.
+        if self.sort_mode.same_field(&sort_mode) && !self.dirs_first {
             self.sort_mode = sort_mode;
             return;
         }
 
-        sort(&mut self.entries, sort_mode);
+        sort(&mut self.entries, sort_mode, self.dirs_first);
 
         self.sort_mode = sort_mode;
+    }
+
+    pub fn toggle_dirs_first(&mut self) {
+        self.dirs_first = !self.dirs_first;
+        sort(&mut self.entries, self.sort_mode, self.dirs_first);
     }
 
     pub fn is_ceph(&self) -> bool {
@@ -573,39 +598,39 @@ fn max_stats(entries: &[DirEntry]) -> (usize, usize) {
     })
 }
 
-fn sort(entries: &mut [DirEntry], sort_mode: SortMode) {
+fn sort(entries: &mut [DirEntry], sort_mode: SortMode, dirs_first: bool) {
+    // `entries` is stored ascending and reversed at read time, so this key has to
+    // flip with the direction: under a reversed mode, directories have to be stored
+    // *last* in order to be displayed first. Symlinks to directories group with the
+    // files, as everywhere else (#12).
+    let group = |e: &DirEntry| -> u8 {
+        if !dirs_first {
+            return 0;
+        }
+        u8::from((e.kind == EntryKind::Dir) == sort_mode.is_reversed())
+    };
+
+    let by_field = |a: &DirEntry, b: &DirEntry| match sort_mode.field() {
+        // The name comparison below is the whole ordering for this field.
+        SortField::Name => Ordering::Equal,
+        SortField::Size => a.size.cmp(&b.size).then(a.rentries.cmp(&b.rentries)),
+        SortField::Rentries => a.rentries.cmp(&b.rentries).then(a.size.cmp(&b.size)),
+        SortField::CTime => a.ctime.cmp(&b.ctime).then(a.size.cmp(&b.size)),
+        SortField::Owner => a
+            .user
+            .cmp(&b.user)
+            .then(a.group.cmp(&b.group))
+            .then(a.size.cmp(&b.size)),
+    };
+
     // Every comparison ends on the name, which is unique within a directory. That
     // makes the order total, so the listing doesn't depend on readdir order.
-    let by_name = |a: &DirEntry, b: &DirEntry| a.name.cmp(&b.name);
-
-    match sort_mode.field() {
-        SortField::Name => entries.sort_by(by_name),
-        SortField::Size => entries.sort_by(|a, b| {
-            a.size
-                .cmp(&b.size)
-                .then(a.rentries.cmp(&b.rentries))
-                .then(by_name(a, b))
-        }),
-        SortField::Rentries => entries.sort_by(|a, b| {
-            a.rentries
-                .cmp(&b.rentries)
-                .then(a.size.cmp(&b.size))
-                .then(by_name(a, b))
-        }),
-        SortField::CTime => entries.sort_by(|a, b| {
-            a.ctime
-                .cmp(&b.ctime)
-                .then(a.size.cmp(&b.size))
-                .then(by_name(a, b))
-        }),
-        SortField::Owner => entries.sort_by(|a, b| {
-            a.user
-                .cmp(&b.user)
-                .then(a.group.cmp(&b.group))
-                .then(a.size.cmp(&b.size))
-                .then(by_name(a, b))
-        }),
-    }
+    entries.sort_by(|a, b| {
+        group(a)
+            .cmp(&group(b))
+            .then_with(|| by_field(a, b))
+            .then_with(|| a.name.cmp(&b.name))
+    });
 }
 
 fn ls(path: &PathBuf) -> Result<(DirEntry, Vec<DirEntry>), std::io::Error> {
@@ -655,6 +680,29 @@ mod tests {
         }
     }
 
+    fn file(name: &str, size: usize) -> DirEntry {
+        DirEntry {
+            kind: EntryKind::File,
+            ..entry(name, size)
+        }
+    }
+
+    /// Two directories and two files, interleaved by size so that grouping them is
+    /// visible in either direction.
+    fn mixed(sort_mode: SortMode, dirs_first: bool) -> DirListing {
+        DirListing::from_entries(
+            vec![
+                entry("d_big/", 300),
+                file("f_huge", 400),
+                entry("d_small/", 100),
+                file("f_mid", 200),
+            ],
+            true,
+            sort_mode,
+            dirs_first,
+        )
+    }
+
     /// Ascending by size: small, medium, large.
     fn listing(has_dotdot: bool, sort_mode: SortMode) -> DirListing {
         DirListing::from_entries(
@@ -665,6 +713,7 @@ mod tests {
             ],
             has_dotdot,
             sort_mode,
+            false,
         )
     }
 
@@ -749,7 +798,7 @@ mod tests {
     /// An empty directory still has "..", and must not be indexed out of bounds.
     #[test]
     fn empty_listing_has_only_dotdot() {
-        let mut listing = DirListing::from_entries(vec![], true, DEFAULT_SORT_MODE);
+        let mut listing = DirListing::from_entries(vec![], true, DEFAULT_SORT_MODE, false);
         assert_eq!(displayed(&listing), [".."]);
         assert_get_matches_display(&listing);
 
@@ -787,7 +836,7 @@ mod tests {
     /// ".." is the only thing left to select in an empty directory.
     #[test]
     fn arriving_in_an_empty_directory_selects_dotdot() {
-        let mut listing = DirListing::from_entries(vec![], true, DEFAULT_SORT_MODE);
+        let mut listing = DirListing::from_entries(vec![], true, DEFAULT_SORT_MODE, false);
         listing.select_first_entry();
         assert_eq!(listing.selected(), Some(0));
         assert_eq!(listing.get(0).name, "..");
@@ -805,7 +854,7 @@ mod tests {
     /// highlighted there. Uses the crate's own tree, which cargo makes the cwd.
     #[test]
     fn cd_selects_the_first_real_entry_then_remembers() {
-        let mut app = App::new(Some(&PathBuf::from(".")), DEFAULT_SORT_MODE).unwrap();
+        let mut app = App::new(Some(&PathBuf::from(".")), DEFAULT_SORT_MODE, false).unwrap();
         assert_eq!(app.dir_listing.selected(), Some(1));
         assert_ne!(app.dir_listing.get(1).name, "..");
 
@@ -853,7 +902,7 @@ mod tests {
     #[test]
     fn new_honors_the_startup_sort_mode() {
         let mode = SortMode::Normal(SortField::Name);
-        let app = App::new(Some(&PathBuf::from(".")), mode).unwrap();
+        let app = App::new(Some(&PathBuf::from(".")), mode, false).unwrap();
         assert_eq!(app.dir_listing.sort_mode(), mode);
 
         let names: Vec<String> = app
@@ -864,6 +913,86 @@ mod tests {
         let mut ascending = names.clone();
         ascending.sort();
         assert_eq!(names, ascending, "listing is not in name order");
+    }
+
+    #[test]
+    fn dirs_first_groups_directories_ahead_of_files() {
+        let interleaved = mixed(SortMode::Reversed(SortField::Size), false);
+        assert_eq!(
+            displayed(&interleaved),
+            ["..", "f_huge", "d_big/", "f_mid", "d_small/"]
+        );
+        assert_get_matches_display(&interleaved);
+
+        // Largest first within each group.
+        let grouped = mixed(SortMode::Reversed(SortField::Size), true);
+        assert_eq!(
+            displayed(&grouped),
+            ["..", "d_big/", "d_small/", "f_huge", "f_mid"]
+        );
+        assert_get_matches_display(&grouped);
+
+        // Smallest first within each group, directories still on top.
+        let ascending = mixed(SortMode::Normal(SortField::Size), true);
+        assert_eq!(
+            displayed(&ascending),
+            ["..", "d_small/", "d_big/", "f_mid", "f_huge"]
+        );
+        assert_get_matches_display(&ascending);
+    }
+
+    /// The grouping key flips with the direction, so a name sort has to group too.
+    #[test]
+    fn dirs_first_groups_under_any_field() {
+        let ascending = mixed(SortMode::Normal(SortField::Name), true);
+        assert_eq!(
+            displayed(&ascending),
+            ["..", "d_big/", "d_small/", "f_huge", "f_mid"]
+        );
+        assert_get_matches_display(&ascending);
+
+        let descending = mixed(SortMode::Reversed(SortField::Name), true);
+        assert_eq!(
+            displayed(&descending),
+            ["..", "d_small/", "d_big/", "f_mid", "f_huge"]
+        );
+        assert_get_matches_display(&descending);
+    }
+
+    /// Reversing normally skips the re-sort, but with dirs_first the stored order
+    /// depends on the direction, so skipping it would put the files on top.
+    #[test]
+    fn dirs_first_survives_a_direction_flip() {
+        let mut listing = mixed(SortMode::Reversed(SortField::Size), true);
+        assert_eq!(
+            displayed(&listing),
+            ["..", "d_big/", "d_small/", "f_huge", "f_mid"]
+        );
+
+        listing.sort(SortMode::Normal(SortField::Size));
+        assert_eq!(
+            displayed(&listing),
+            ["..", "d_small/", "d_big/", "f_mid", "f_huge"],
+            "the direction-only short-circuit skipped the regrouping"
+        );
+        assert_get_matches_display(&listing);
+    }
+
+    #[test]
+    fn toggling_dirs_first_regroups() {
+        let mut listing = mixed(SortMode::Reversed(SortField::Size), false);
+        let interleaved = displayed(&listing);
+
+        listing.toggle_dirs_first();
+        assert_eq!(
+            displayed(&listing),
+            ["..", "d_big/", "d_small/", "f_huge", "f_mid"]
+        );
+        assert_get_matches_display(&listing);
+
+        listing.toggle_dirs_first();
+        assert_eq!(displayed(&listing), interleaved);
+        assert_get_matches_display(&listing);
     }
 
     /// Names break ties so that the listing doesn't depend on readdir order.
@@ -877,7 +1006,7 @@ mod tests {
             SortField::CTime,
             SortField::Owner,
         ] {
-            let listing = DirListing::from_entries(tied(), false, SortMode::Normal(field));
+            let listing = DirListing::from_entries(tied(), false, SortMode::Normal(field), false);
             assert_eq!(
                 displayed(&listing),
                 ["a", "b", "c"],

--- a/src/app.rs
+++ b/src/app.rs
@@ -136,6 +136,17 @@ pub enum SortField {
 }
 
 impl SortField {
+    /// The name this field goes by in the interface and on the command line.
+    pub const fn label(self) -> &'static str {
+        match self {
+            SortField::Name => "name",
+            SortField::Size => "size",
+            SortField::Rentries => "count",
+            SortField::Owner => "owner",
+            SortField::CTime => "time",
+        }
+    }
+
     /// The direction a field starts in when it is first chosen, by key or by flag.
     /// Sizes, counts and times read most-first; names and owners read ascending.
     pub const fn default_mode(self) -> SortMode {
@@ -564,6 +575,10 @@ impl DirListing {
         sort(&mut self.entries, sort_mode, self.dirs_first);
 
         self.sort_mode = sort_mode;
+    }
+
+    pub fn dirs_first(&self) -> bool {
+        self.dirs_first
     }
 
     pub fn toggle_dirs_first(&mut self) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -136,7 +136,113 @@ impl ListingWatch {
 /// A listing worker's answer. `generation` says which request it answers.
 pub struct ListingMsg {
     generation: u64,
-    result: Result<(PathBuf, DirListing), std::io::Error>,
+    result: Result<Fetched, std::io::Error>,
+}
+
+/// What a worker fetched: a whole listing (a cd or refresh), or columns to add
+/// to the listing already on screen. Columns are how a toggle or a sort acquires
+/// what the listing was read without: the entries are already in hand, so only
+/// the missing values are fetched -- no readdir, and nothing already read is
+/// touched, which is what keeps every column cached until the directory itself
+/// is left or refreshed.
+enum Fetched {
+    Listing(PathBuf, Box<DirListing>),
+    Columns {
+        /// Which columns the patches carry (only `owners`/`times` meaningful).
+        added: Options,
+        patches: Vec<ColumnPatch>,
+    },
+}
+
+/// One entry's worth of column fetching: what to read, keyed back by name.
+struct ColumnTask {
+    name: String,
+    path: PathBuf,
+    kind: EntryKind,
+    uid: Option<u32>,
+    gid: Option<u32>,
+}
+
+/// The values fetched for one entry. A field is only applied if `added` names
+/// its column, so a `None` here is a real answer (nothing there), not a gap.
+struct ColumnPatch {
+    name: String,
+    ctime: Option<usize>,
+    user: Option<String>,
+    group: Option<String>,
+}
+
+/// The per-entry work of a column fetch. A directory's time is one xattr and its
+/// owner one stat; a file's time and ids were kept from the stat the listing
+/// already did, so its owner is just the uid-to-name lookup.
+fn fetch_columns_for(task: &ColumnTask, added: &Options) -> ColumnPatch {
+    let ctime = if added.times && task.kind == EntryKind::Dir {
+        get_rctime(&task.path)
+    } else {
+        None
+    };
+
+    let (user, group) = if added.owners {
+        let (uid, gid) = if task.kind == EntryKind::Dir {
+            match std::fs::symlink_metadata(&task.path) {
+                Ok(stat) => (Some(stat.uid()), Some(stat.gid())),
+                // The entry may be gone by now; an unknowable owner, not an error.
+                Err(_) => (None, None),
+            }
+        } else {
+            (task.uid, task.gid)
+        };
+        (uid.and_then(name_or_id), gid.and_then(name_or_id))
+    } else {
+        (None, None)
+    };
+
+    ColumnPatch {
+        name: task.name.clone(),
+        ctime,
+        user,
+        group,
+    }
+}
+
+/// Run the column fetches, `jobs` at a time. No feed channel here, unlike
+/// `read_streamed`: the tasks are already in memory, so there is no readdir to
+/// overlap with or to pace. Cancellation just stops early -- the answer is
+/// already orphaned on the other side.
+fn fetch_columns(tasks: &[ColumnTask], added: &Options, watch: &ListingWatch) -> Vec<ColumnPatch> {
+    let one = |task: &ColumnTask| {
+        let patch = fetch_columns_for(task, added);
+        watch.saw_one();
+        patch
+    };
+
+    if added.jobs <= 1 {
+        tasks
+            .iter()
+            .take_while(|_| !watch.cancelled())
+            .map(one)
+            .collect()
+    } else {
+        std::thread::scope(|s| {
+            let workers: Vec<_> = (0..added.jobs)
+                .map(|w| {
+                    s.spawn(move || {
+                        tasks
+                            .iter()
+                            .skip(w)
+                            .step_by(added.jobs)
+                            .take_while(|_| !watch.cancelled())
+                            .map(one)
+                            .collect::<Vec<_>>()
+                    })
+                })
+                .collect();
+            workers
+                .into_iter()
+                .flat_map(|w| w.join().unwrap())
+                .collect()
+        })
+    }
 }
 
 /// A listing not yet arrived: the request's identity, its watch, and what to do if
@@ -194,6 +300,10 @@ pub struct DirEntry {
     pub ctime: Option<usize>,
     pub user: Option<String>,
     pub group: Option<String>,
+    /// Kept from whatever stat the entry already had, whether or not the owner
+    /// was resolved: showing the owner later then costs a file nothing.
+    pub(crate) uid: Option<u32>,
+    pub(crate) gid: Option<u32>,
 }
 
 impl DirEntry {
@@ -245,10 +355,8 @@ impl DirEntry {
             name_str.to_string()
         };
 
-        let name_or_id = |id: u32| id_to_name(id).unwrap_or_else(|| format!("{}", id));
-
         let (user, group) = match stat.as_ref().filter(|_| options.owners) {
-            Some(stat) => (Some(name_or_id(stat.uid())), Some(name_or_id(stat.gid()))),
+            Some(stat) => (name_or_id(stat.uid()), name_or_id(stat.gid())),
             None => (None, None),
         };
 
@@ -260,6 +368,8 @@ impl DirEntry {
             ctime,
             user,
             group,
+            uid: stat.as_ref().map(|s| s.uid()),
+            gid: stat.as_ref().map(|s| s.gid()),
         }
     }
 }
@@ -385,39 +495,81 @@ impl App {
     /// so that one blocked in a syscall can never stall anything else -- quitting
     /// included -- and so this needs no runtime to be running.
     pub fn start_listing(&mut self, path: PathBuf, on_error: OnError, preserve_message: bool) {
+        // What a new directory fetches follows the columns and sort, not what the
+        // current listing happened to be read with: leaving a directory with the
+        // owner hidden should not make the next one pay for it.
+        let options = self.needs();
+        let (generation, watch, tx) = self.supersede(path.clone(), on_error, preserve_message);
+        let worker = move || {
+            let result = path.canonicalize().and_then(|canon| {
+                DirListing::from_watched(&canon, options, &watch)
+                    .map(|l| Fetched::Listing(canon, Box::new(l)))
+            });
+            // The receiver is gone only when the app is; nowhere to report to.
+            let _ = tx.send(ListingMsg { generation, result });
+        };
+        std::thread::spawn(worker);
+    }
+
+    /// Fetch `added`'s columns for the listing on screen and merge them in,
+    /// leaving every other column exactly as it is. This is how a toggle or a
+    /// sort acquires what the listing was read without: the entries are already
+    /// in hand, so a whole re-read -- readdir, sizes, counts -- would fetch
+    /// nothing it doesn't already have.
+    fn start_columns(&mut self, added: Options) {
+        let tasks: Vec<ColumnTask> = self
+            .dir_listing
+            .entries
+            .iter()
+            // A file's time and ids came with the stat the listing already did,
+            // so only the owner lookup can be outstanding for it.
+            .filter(|e| added.owners || e.kind == EntryKind::Dir)
+            .map(|e| ColumnTask {
+                name: e.name.clone(),
+                // The directory `/` is display, not filename.
+                path: self.cwd.join(e.name.trim_end_matches('/')),
+                kind: e.kind,
+                uid: e.uid,
+                gid: e.gid,
+            })
+            .collect();
+
+        let (generation, watch, tx) = self.supersede(self.cwd.clone(), OnError::Message, false);
+        // The whole read is priced by construction; no xattr needed.
+        watch.set_total(tasks.len());
+        let worker = move || {
+            let patches = fetch_columns(&tasks, &added, &watch);
+            let _ = tx.send(ListingMsg {
+                generation,
+                result: Ok(Fetched::Columns { added, patches }),
+            });
+        };
+        std::thread::spawn(worker);
+    }
+
+    /// Supersede whatever read is in flight and register the new one. The caller
+    /// spawns the worker with the handles this returns.
+    fn supersede(
+        &mut self,
+        path: PathBuf,
+        on_error: OnError,
+        preserve_message: bool,
+    ) -> (u64, Arc<ListingWatch>, UnboundedSender<ListingMsg>) {
         if let Some(old) = self.pending.take() {
             old.watch.cancel();
         }
         self.generation += 1;
-        let generation = self.generation;
         let watch = Arc::new(ListingWatch::new());
-        // What the read fetches follows the columns and sort, not what the current
-        // listing happened to be read with: leaving a directory with the owner
-        // hidden should not make the next one pay for it.
-        let options = self.needs();
-
-        let tx = self.tx.clone();
-        let worker = {
-            let path = path.clone();
-            let watch = watch.clone();
-            move || {
-                let result = path.canonicalize().and_then(|canon| {
-                    DirListing::from_watched(&canon, options, &watch).map(|l| (canon, l))
-                });
-                // The receiver is gone only when the app is; nowhere to report to.
-                let _ = tx.send(ListingMsg { generation, result });
-            }
-        };
-        std::thread::spawn(worker);
 
         self.pending = Some(Pending {
-            generation,
+            generation: self.generation,
             path,
-            watch,
+            watch: watch.clone(),
             started: Instant::now(),
             on_error,
             preserve_message,
         });
+        (self.generation, watch, self.tx.clone())
     }
 
     /// Apply a worker's answer, unless it answers a request that is no longer the
@@ -429,12 +581,18 @@ impl App {
         let pending = self.pending.take().unwrap();
 
         match msg.result {
-            Ok((path, listing)) => {
+            Ok(Fetched::Listing(path, mut listing)) => {
+                // The sort or grouping may have changed while the read was in
+                // flight; the screen's current choice wins over dispatch-time's.
+                if listing.dirs_first() != self.dir_listing.dirs_first() {
+                    listing.toggle_dirs_first();
+                }
+                listing.sort(self.dir_listing.sort_mode());
                 // Record which entry was highlighted in case we navigate back.
                 // Saved now, not at dispatch, so moving the cursor while the read
                 // ran isn't undone.
                 self.save_selected();
-                self.dir_listing = listing;
+                self.dir_listing = *listing;
                 self.cwd = path;
                 if self.original_cwd.is_none() {
                     self.original_cwd = Some(self.cwd.clone());
@@ -453,6 +611,13 @@ impl App {
                 self.restore_selected();
                 // A column toggled or a sort begun while the read ran may need
                 // more than it fetched.
+                self.fetch_if_needed();
+            }
+            Ok(Fetched::Columns { added, patches }) => {
+                self.save_selected();
+                self.dir_listing.absorb(added, patches);
+                // The merge re-sorts, so the cursor follows its entry by name.
+                self.restore_selected();
                 self.fetch_if_needed();
             }
             Err(e) => match pending.on_error {
@@ -534,10 +699,22 @@ impl App {
     /// `options` records what the listing *has*, so one that already has it is left
     /// alone however many times a column is toggled.
     fn fetch_if_needed(&mut self) {
+        // Whatever lands next -- a cd, a refresh, another column -- re-checks on
+        // arrival, so deferring here converges on the right target instead of
+        // cancelling an in-flight read to fetch columns for a directory that is
+        // about to be replaced.
+        if self.pending.is_some() {
+            return;
+        }
         let needs = self.needs();
         let has = self.dir_listing.options;
-        if (needs.owners && !has.owners) || (needs.times && !has.times) {
-            self.cd(&self.cwd.clone());
+        let added = Options {
+            owners: needs.owners && !has.owners,
+            times: needs.times && !has.times,
+            ..needs
+        };
+        if added.owners || added.times {
+            self.start_columns(added);
         }
     }
 
@@ -877,6 +1054,44 @@ impl DirListing {
         self.options.dirs_first
     }
 
+    /// Merge fetched columns into the listing, touching nothing else: every
+    /// value the listing already has stays exactly as it is. Entries are matched
+    /// by name, so one that vanished since the listing was read is skipped. The
+    /// listing then re-sorts, since the point of fetching a column is often to
+    /// order by it.
+    fn absorb(&mut self, added: Options, patches: Vec<ColumnPatch>) {
+        let index: HashMap<String, usize> = self
+            .entries
+            .iter()
+            .enumerate()
+            .map(|(i, e)| (e.name.clone(), i))
+            .collect();
+
+        for patch in patches {
+            let Some(&i) = index.get(&patch.name) else {
+                continue;
+            };
+            let entry = &mut self.entries[i];
+            // Only a directory's time was fetched; a file's came with its stat
+            // and must not be clobbered by the patch's placeholder.
+            if added.times && entry.kind == EntryKind::Dir {
+                entry.ctime = patch.ctime;
+            }
+            if added.owners {
+                entry.user = patch.user;
+                entry.group = patch.group;
+            }
+        }
+
+        self.options.owners |= added.owners;
+        self.options.times |= added.times;
+        sort(
+            &mut self.entries,
+            self.options.sort_mode,
+            self.options.dirs_first,
+        );
+    }
+
     pub fn toggle_dirs_first(&mut self) {
         self.options.dirs_first = !self.options.dirs_first;
         sort(
@@ -901,7 +1116,13 @@ fn dotdot_entry() -> DirEntry {
         ctime: None,
         user: None,
         group: None,
+        uid: None,
+        gid: None,
     }
+}
+
+fn name_or_id(id: u32) -> Option<String> {
+    Some(id_to_name(id).unwrap_or_else(|| format!("{}", id)))
 }
 
 /// The largest size and rentries in the listing, which set the gauge scales.
@@ -1123,6 +1344,8 @@ mod tests {
             ctime: Some(size),
             user: Some("alice".to_string()),
             group: Some("scc".to_string()),
+            uid: None,
+            gid: None,
         }
     }
 
@@ -1546,6 +1769,115 @@ mod tests {
             app.dir_listing.entries[0].ctime,
             Some(12_345),
             "the directory was read again"
+        );
+    }
+
+    /// Fetching one column must leave every other exactly as it is: the columns
+    /// cache independently, and only leaving or refreshing the directory drops
+    /// them. Alternating `u` and `t` used to pay for the same data twice, because
+    /// the fetch was a whole re-read built from what was currently shown.
+    #[test]
+    fn fetching_one_column_leaves_the_others_in_place() {
+        let (mut app, mut listings) = app_at(".", Options::default());
+
+        app.toggle_owner();
+        app.pump(&mut listings);
+        assert!(
+            app.dir_listing.options().owners,
+            "the first show did not read"
+        );
+
+        // Hidden, but still read -- the cache that makes re-showing free.
+        app.toggle_owner();
+        app.pump(&mut listings);
+        assert!(app.dir_listing.options().owners);
+
+        // Values only a re-read of the listing could overwrite: fetching the
+        // time must not refetch the owner, the sizes, or anything else in hand.
+        app.dir_listing.entries[0].user = Some("sentinel".to_string());
+        app.dir_listing.entries[0].size = Some(424_242);
+
+        app.toggle_ctime();
+        app.pump(&mut listings);
+        assert!(app.dir_listing.options().times, "the time was not read");
+        assert!(
+            app.dir_listing.options().owners,
+            "the fetch for the time dropped the owner"
+        );
+        let planted = app
+            .dir_listing
+            .entries
+            .iter()
+            .find(|e| e.size == Some(424_242))
+            .expect("the fetch for the time re-read the sizes");
+        assert_eq!(
+            planted.user.as_deref(),
+            Some("sentinel"),
+            "the fetch for the time re-read the owner"
+        );
+
+        // So showing the owner again costs nothing.
+        app.toggle_owner();
+        assert!(
+            !app.is_reading(),
+            "showing the owner again re-read the directory"
+        );
+    }
+
+    /// The point of fetching a column is often to order by it, so the merge
+    /// re-sorts. Synthetic listing and patches, so the values are certain.
+    #[test]
+    fn absorbing_a_column_re_sorts_by_it() {
+        let mut listing = DirListing::from_entries(
+            vec![
+                DirEntry {
+                    ctime: None,
+                    ..entry("young/", 1)
+                },
+                DirEntry {
+                    ctime: None,
+                    ..entry("old/", 2)
+                },
+            ],
+            false,
+            Options::sorted(SortField::CTime.default_mode()),
+        );
+        // Times unknown, so the order is the name tie-break.
+        assert_eq!(displayed(&listing), ["old/", "young/"]);
+
+        listing.absorb(
+            Options {
+                times: true,
+                ..Options::default()
+            },
+            vec![
+                ColumnPatch {
+                    name: "young/".to_string(),
+                    ctime: Some(2_000),
+                    user: None,
+                    group: None,
+                },
+                ColumnPatch {
+                    name: "old/".to_string(),
+                    ctime: Some(1_000),
+                    user: None,
+                    group: None,
+                },
+                // An entry that vanished between the listing and the fetch.
+                ColumnPatch {
+                    name: "gone/".to_string(),
+                    ctime: Some(3_000),
+                    user: None,
+                    group: None,
+                },
+            ],
+        );
+
+        assert!(listing.options().times);
+        assert_eq!(
+            displayed(&listing),
+            ["young/", "old/"],
+            "the merged times did not re-sort the listing"
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -305,7 +305,7 @@ impl App {
 }
 
 impl DirListing {
-    fn from(path: &Path, sort_mode: SortMode) -> Result<DirListing, std::io::Error> {
+    pub fn from(path: &Path, sort_mode: SortMode) -> Result<DirListing, std::io::Error> {
         let path: PathBuf = path.canonicalize()?;
         let fs = get_fs(&path);
 
@@ -396,19 +396,22 @@ impl DirListing {
         }
     }
 
-    pub fn iter_entries(&self) -> impl Iterator<Item = &DirEntry> {
-        // Display ".." first if we have it, then the rest of the entries,
-        // maybe in reverse order.
-
-        let dotdot = self.dotdot.iter();
-
+    /// Iterate the real entries in display order, without "..".
+    pub fn iter_entries_sorted(&self) -> impl Iterator<Item = &DirEntry> {
+        // `entries` is always sorted ascending; reversed modes are applied here
+        // rather than by re-sorting.
         let entries_iter: Box<dyn Iterator<Item = &DirEntry>> = if self.sort_mode.is_reversed() {
             Box::new(self.entries.iter().rev())
         } else {
             Box::new(self.entries.iter())
         };
 
-        dotdot.chain(entries_iter)
+        entries_iter
+    }
+
+    /// Iterate the entries as displayed: ".." first if we have it, then the rest.
+    pub fn iter_entries(&self) -> impl Iterator<Item = &DirEntry> {
+        self.dotdot.iter().chain(self.iter_entries_sorted())
     }
 
     pub fn get(&self, idx: usize) -> &DirEntry {
@@ -686,6 +689,7 @@ mod tests {
             let listing = listing(true, sort_mode);
             assert_eq!(displayed(&listing)[0], "..");
             assert_eq!(listing.len(), 4);
+            assert_eq!(listing.iter_entries_sorted().count(), 3);
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -64,6 +64,17 @@ pub struct DirEntry {
 }
 
 impl DirEntry {
+    /// The name as shown to a person, marked the way `ls -F` marks: a trailing `@`
+    /// for a symlink. The directory's `/` is already part of `name` instead, because
+    /// the parseable format documents it and `/` is the one byte a filename cannot
+    /// contain. `@` can, so it stays out of that stream and is applied here.
+    pub fn display_name(&self) -> String {
+        match self.kind {
+            EntryKind::Symlink => format!("{}@", self.name),
+            _ => self.name.clone(),
+        }
+    }
+
     fn from(path: PathBuf, stat: Metadata) -> Self {
         let kind = if stat.is_dir() {
             EntryKind::Dir
@@ -889,6 +900,30 @@ mod tests {
         app.cd(&PathBuf::from(".."));
         let selected = app.dir_listing.selected().unwrap();
         assert_eq!(app.dir_listing.get(selected).name, "src/");
+    }
+
+    /// Symlinks are marked where a person reads the name, not in the machine stream:
+    /// a filename may contain `@`, so it cannot signal anything there.
+    #[test]
+    fn symlinks_are_marked_for_display_only() {
+        let link = DirEntry {
+            kind: EntryKind::Symlink,
+            ..entry("target", 10)
+        };
+        assert_eq!(link.display_name(), "target@");
+        assert_eq!(link.name, "target");
+
+        // A file whose name ends in @ is left alone, and a directory keeps the `/`
+        // that `from` already gave it.
+        let odd = DirEntry {
+            kind: EntryKind::File,
+            ..entry("notes@", 10)
+        };
+        assert_eq!(odd.display_name(), "notes@");
+
+        let dir = entry("data/", 10);
+        assert_eq!(dir.kind, EntryKind::Dir);
+        assert_eq!(dir.display_name(), "data/");
     }
 
     /// The sort keys and the CLI sort flags share these directions, so they cannot

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,6 +15,46 @@ use crate::popup::Popup;
 
 pub const DEFAULT_SORT_MODE: SortMode = SortField::Size.default_mode();
 
+/// How a directory is read and ordered. Carried across directory changes, and the
+/// reason `DirListing::from` takes one value rather than a run of booleans.
+#[derive(Debug, Clone, Copy)]
+pub struct Options {
+    pub sort_mode: SortMode,
+    pub dirs_first: bool,
+    /// Whether to stat for the owner. Off by default because a directory needs no
+    /// stat at all without it: its size, count and kind all come from elsewhere. The
+    /// uid-to-name lookup is the cheap half -- measured at ~18us from SSSD's cache on
+    /// Rusty against 1.37ms for one xattr read -- so it is the stat that is saved.
+    pub owners: bool,
+    /// Whether to read a directory's recursive time. Off by default because it is a
+    /// third of the xattr round trips a listing makes, and measurably so: 42s to 30s
+    /// on ten thousand directories. A file's time comes from the stat it needs
+    /// anyway, so this only concerns directories.
+    pub times: bool,
+}
+
+impl Options {
+    /// Just the ordering, with the defaults for the rest.
+    #[cfg(test)]
+    pub fn sorted(sort_mode: SortMode) -> Options {
+        Options {
+            sort_mode,
+            ..Options::default()
+        }
+    }
+}
+
+impl Default for Options {
+    fn default() -> Options {
+        Options {
+            sort_mode: DEFAULT_SORT_MODE,
+            dirs_first: false,
+            owners: false,
+            times: false,
+        }
+    }
+}
+
 pub struct App {
     pub should_exit: bool,
     pub cwd: PathBuf,
@@ -37,8 +77,7 @@ pub struct DirListing {
     dotdot: Option<DirEntry>,
     entries: Vec<DirEntry>,
     state: ListState,
-    sort_mode: SortMode,
-    dirs_first: bool,
+    options: Options,
     pub stats: ListingStats,
     pub fs: Option<FSType>,
 }
@@ -75,15 +114,13 @@ impl DirEntry {
         }
     }
 
-    fn from(path: PathBuf, stat: Metadata) -> Self {
-        let kind = if stat.is_dir() {
-            EntryKind::Dir
-        } else if stat.is_symlink() {
-            EntryKind::Symlink
-        } else {
-            EntryKind::File
-        };
-
+    /// `stat` is absent when nothing needed it: a directory's size and count come
+    /// from the xattrs and its kind from readdir, so the only thing left for a stat
+    /// to answer is who owns it. What to fetch is read from `options` rather than
+    /// inferred from the stat: a file is stat'd for its size regardless, so for a file
+    /// the only thing `owners` saves is the uid-to-name lookup, once per distinct
+    /// owner.
+    fn from(path: PathBuf, kind: EntryKind, stat: Option<Metadata>, options: &Options) -> Self {
         // we want to do our xattr calls asap to try and take advantage of MDS caching
         let rentries: Option<usize> = if kind == EntryKind::Dir {
             // rentries seems to include the self-count, which is confusing when there are
@@ -96,13 +133,15 @@ impl DirEntry {
         let size: Option<usize> = if kind == EntryKind::Dir {
             get_rbytes(&path)
         } else {
-            Some(stat.len() as usize)
+            stat.as_ref().map(|s| s.len() as usize)
         };
 
         let ctime: Option<usize> = if kind == EntryKind::Dir {
-            get_rctime(&path)
+            // A third of the round trips a listing makes, and only wanted when the
+            // time is on screen or being sorted by.
+            options.times.then(|| get_rctime(&path)).flatten()
         } else {
-            Some(stat.ctime() as usize)
+            stat.as_ref().map(|s| s.ctime() as usize)
         };
 
         let name_str = path.file_name().unwrap_or_default().to_string_lossy();
@@ -114,8 +153,10 @@ impl DirEntry {
 
         let name_or_id = |id: u32| id_to_name(id).unwrap_or_else(|| format!("{}", id));
 
-        let user = Some(name_or_id(stat.uid()));
-        let group = Some(name_or_id(stat.gid()));
+        let (user, group) = match stat.as_ref().filter(|_| options.owners) {
+            Some(stat) => (Some(name_or_id(stat.uid())), Some(name_or_id(stat.gid()))),
+            None => (None, None),
+        };
 
         DirEntry {
             name,
@@ -211,18 +252,14 @@ pub enum MessageKind {
 }
 
 impl App {
-    pub fn new(
-        cwd: Option<&PathBuf>,
-        sort_mode: SortMode,
-        dirs_first: bool,
-    ) -> Result<App, std::io::Error> {
+    pub fn new(cwd: Option<&PathBuf>, options: Options) -> Result<App, std::io::Error> {
         let cwd: PathBuf = if let Some(cwd) = cwd {
             cwd.clone()
         } else {
             std::env::current_dir()?
         };
 
-        let dir_listing = DirListing::empty(sort_mode, dirs_first);
+        let dir_listing = DirListing::empty(options);
         let original_cwd = cwd.clone();
         let mut app = App {
             should_exit: false,
@@ -264,11 +301,11 @@ impl App {
         } else {
             self.cwd.join(path).canonicalize()?
         };
-        self.dir_listing = DirListing::from(
-            &new,
-            self.dir_listing.sort_mode,
-            self.dir_listing.dirs_first,
-        )?;
+        // What the next read fetches follows the column, not what this listing
+        // happened to be read with: leaving a directory with the owner hidden should
+        // not make the next one pay for it.
+        let options = self.needs();
+        self.dir_listing = DirListing::from(&new, options)?;
         self.cwd = new;
         if !self.dir_listing.is_ceph() {
             self.message(Some(Message {
@@ -282,6 +319,38 @@ impl App {
         // Restore the highlighted entry if we have one
         self.restore_selected();
         Ok(())
+    }
+
+    /// What a read of this directory would have to fetch: a column needs its value,
+    /// and so does ordering by it, whether or not it is on screen.
+    fn needs(&self) -> Options {
+        let field = *self.dir_listing.sort_mode().field();
+        Options {
+            owners: self.show_owner || field == SortField::Owner,
+            times: self.show_ctime || field == SortField::CTime,
+            ..self.dir_listing.options
+        }
+    }
+
+    /// Re-read when something has come to need what this listing never fetched.
+    /// `options` records what the listing *has*, so one that already has it is left
+    /// alone however many times a column is toggled.
+    fn fetch_if_needed(&mut self) {
+        let needs = self.needs();
+        let has = self.dir_listing.options;
+        if (needs.owners && !has.owners) || (needs.times && !has.times) {
+            self.cd(&self.cwd.clone());
+        }
+    }
+
+    pub fn toggle_owner(&mut self) {
+        self.show_owner = !self.show_owner;
+        self.fetch_if_needed();
+    }
+
+    pub fn toggle_ctime(&mut self) {
+        self.show_ctime = !self.show_ctime;
+        self.fetch_if_needed();
     }
 
     pub fn popup(&mut self, title: Option<&str>, bottom_title: Option<&str>, text: Option<&str>) {
@@ -328,7 +397,10 @@ impl App {
             } else {
                 sort_mode
             },
-        )
+        );
+        // Ordering by owner or by time is the other thing that needs a read, and the
+        // sort mode is already in place, so the re-read lands in the right order.
+        self.fetch_if_needed();
     }
 
     /// Save the currently selected entry in the highlighted map.
@@ -355,15 +427,11 @@ impl App {
 }
 
 impl DirListing {
-    pub fn from(
-        path: &Path,
-        sort_mode: SortMode,
-        dirs_first: bool,
-    ) -> Result<DirListing, std::io::Error> {
+    pub fn from(path: &Path, options: Options) -> Result<DirListing, std::io::Error> {
         let path: PathBuf = path.canonicalize()?;
         let fs = get_fs(&path);
 
-        let (entry_cwd, mut entries): (DirEntry, Vec<DirEntry>) = ls(&path)?;
+        let (entry_cwd, mut entries): (DirEntry, Vec<DirEntry>) = ls(&path, &options)?;
 
         // Don't trust dir sizes on non-ceph!
         if !fs.map(FSType::is_ceph).unwrap_or(false) {
@@ -374,7 +442,7 @@ impl DirListing {
                     e.size = None;
                 });
         }
-        sort(&mut entries, sort_mode, dirs_first);
+        sort(&mut entries, options.sort_mode, options.dirs_first);
 
         let has_parent = *path != *"/";
         let dotdot = has_parent.then(dotdot_entry);
@@ -397,8 +465,7 @@ impl DirListing {
             entries,
             state,
             dotdot,
-            sort_mode,
-            dirs_first,
+            options,
             stats: ListingStats {
                 max_rentries,
                 total_rentries,
@@ -414,10 +481,9 @@ impl DirListing {
     pub fn from_entries(
         mut entries: Vec<DirEntry>,
         has_dotdot: bool,
-        sort_mode: SortMode,
-        dirs_first: bool,
+        options: Options,
     ) -> DirListing {
-        sort(&mut entries, sort_mode, dirs_first);
+        sort(&mut entries, options.sort_mode, options.dirs_first);
 
         let (max_rentries, max_size) = max_stats(&entries);
 
@@ -431,19 +497,17 @@ impl DirListing {
             },
             entries,
             state: ListState::default().with_selected(Some(0)),
-            sort_mode,
-            dirs_first,
+            options,
             fs: None,
         }
     }
 
-    fn empty(sort_mode: SortMode, dirs_first: bool) -> DirListing {
+    fn empty(options: Options) -> DirListing {
         DirListing {
             dotdot: None,
             entries: Vec::new(),
             state: ListState::default(),
-            sort_mode,
-            dirs_first,
+            options,
             stats: ListingStats {
                 max_rentries: 0,
                 total_rentries: 0,
@@ -458,11 +522,12 @@ impl DirListing {
     pub fn iter_entries_sorted(&self) -> impl Iterator<Item = &DirEntry> {
         // `entries` is always sorted ascending; reversed modes are applied here
         // rather than by re-sorting.
-        let entries_iter: Box<dyn Iterator<Item = &DirEntry>> = if self.sort_mode.is_reversed() {
-            Box::new(self.entries.iter().rev())
-        } else {
-            Box::new(self.entries.iter())
-        };
+        let entries_iter: Box<dyn Iterator<Item = &DirEntry>> =
+            if self.options.sort_mode.is_reversed() {
+                Box::new(self.entries.iter().rev())
+            } else {
+                Box::new(self.entries.iter())
+            };
 
         entries_iter
     }
@@ -485,7 +550,7 @@ impl DirListing {
             idx
         };
 
-        if self.sort_mode.is_reversed() {
+        if self.options.sort_mode.is_reversed() {
             &self.entries[self.entries.len() - idx - 1]
         } else {
             &self.entries[idx]
@@ -579,29 +644,37 @@ impl DirListing {
     }
 
     pub fn sort_mode(&self) -> SortMode {
-        self.sort_mode
+        self.options.sort_mode
+    }
+
+    pub fn options(&self) -> Options {
+        self.options
     }
 
     pub fn sort(&mut self, sort_mode: SortMode) {
         // Reversing normally needs no re-sort, but with dirs_first the stored order
         // depends on the direction, so only the plain case can short-circuit.
-        if self.sort_mode.same_field(&sort_mode) && !self.dirs_first {
-            self.sort_mode = sort_mode;
+        if self.options.sort_mode.same_field(&sort_mode) && !self.options.dirs_first {
+            self.options.sort_mode = sort_mode;
             return;
         }
 
-        sort(&mut self.entries, sort_mode, self.dirs_first);
+        sort(&mut self.entries, sort_mode, self.options.dirs_first);
 
-        self.sort_mode = sort_mode;
+        self.options.sort_mode = sort_mode;
     }
 
     pub fn dirs_first(&self) -> bool {
-        self.dirs_first
+        self.options.dirs_first
     }
 
     pub fn toggle_dirs_first(&mut self) {
-        self.dirs_first = !self.dirs_first;
-        sort(&mut self.entries, self.sort_mode, self.dirs_first);
+        self.options.dirs_first = !self.options.dirs_first;
+        sort(
+            &mut self.entries,
+            self.options.sort_mode,
+            self.options.dirs_first,
+        );
     }
 
     pub fn is_ceph(&self) -> bool {
@@ -666,8 +739,14 @@ fn sort(entries: &mut [DirEntry], sort_mode: SortMode, dirs_first: bool) {
     });
 }
 
-fn ls(path: &PathBuf) -> Result<(DirEntry, Vec<DirEntry>), std::io::Error> {
-    let entry_cwd = DirEntry::from(PathBuf::from(path), fs::metadata(path)?);
+fn ls(path: &PathBuf, options: &Options) -> Result<(DirEntry, Vec<DirEntry>), std::io::Error> {
+    // The cwd is only here for its totals, so it needs neither a stat nor a time.
+    let totals = Options {
+        owners: false,
+        times: false,
+        ..*options
+    };
+    let entry_cwd = DirEntry::from(PathBuf::from(path), EntryKind::Dir, None, &totals);
     let dir_iterator = fs::read_dir(path)?;
     let mut entries: Vec<DirEntry> = Vec::new();
 
@@ -690,8 +769,27 @@ fn ls(path: &PathBuf) -> Result<(DirEntry, Vec<DirEntry>), std::io::Error> {
 
         let entry = entry_result?;
         let path = entry.path();
-        let metadata = entry.metadata()?;
-        entries.push(DirEntry::from(path, metadata));
+
+        // readdir already reported the type, so file_type() only falls back to a
+        // stat of its own where the filesystem returned DT_UNKNOWN.
+        let file_type = entry.file_type()?;
+        let kind = if file_type.is_dir() {
+            EntryKind::Dir
+        } else if file_type.is_symlink() {
+            EntryKind::Symlink
+        } else {
+            EntryKind::File
+        };
+
+        // A file's size and time are the stat's alone; a directory needs one only to
+        // say who owns it.
+        let stat = if kind == EntryKind::Dir && !options.owners {
+            None
+        } else {
+            Some(entry.metadata()?)
+        };
+
+        entries.push(DirEntry::from(path, kind, stat, options));
     }
 
     Ok((entry_cwd, entries))
@@ -731,8 +829,11 @@ mod tests {
                 file("f_mid", 200),
             ],
             true,
-            sort_mode,
-            dirs_first,
+            Options {
+                sort_mode,
+                dirs_first,
+                ..Options::default()
+            },
         )
     }
 
@@ -745,8 +846,7 @@ mod tests {
                 entry("medium", 200),
             ],
             has_dotdot,
-            sort_mode,
-            false,
+            Options::sorted(sort_mode),
         )
     }
 
@@ -831,7 +931,15 @@ mod tests {
     /// An empty directory still has "..", and must not be indexed out of bounds.
     #[test]
     fn empty_listing_has_only_dotdot() {
-        let mut listing = DirListing::from_entries(vec![], true, DEFAULT_SORT_MODE, false);
+        let mut listing = DirListing::from_entries(
+            vec![],
+            true,
+            Options {
+                sort_mode: DEFAULT_SORT_MODE,
+                dirs_first: false,
+                ..Options::default()
+            },
+        );
         assert_eq!(displayed(&listing), [".."]);
         assert_get_matches_display(&listing);
 
@@ -869,7 +977,15 @@ mod tests {
     /// ".." is the only thing left to select in an empty directory.
     #[test]
     fn arriving_in_an_empty_directory_selects_dotdot() {
-        let mut listing = DirListing::from_entries(vec![], true, DEFAULT_SORT_MODE, false);
+        let mut listing = DirListing::from_entries(
+            vec![],
+            true,
+            Options {
+                sort_mode: DEFAULT_SORT_MODE,
+                dirs_first: false,
+                ..Options::default()
+            },
+        );
         listing.select_first_entry();
         assert_eq!(listing.selected(), Some(0));
         assert_eq!(listing.get(0).name, "..");
@@ -887,7 +1003,7 @@ mod tests {
     /// highlighted there. Uses the crate's own tree, which cargo makes the cwd.
     #[test]
     fn cd_selects_the_first_real_entry_then_remembers() {
-        let mut app = App::new(Some(&PathBuf::from(".")), DEFAULT_SORT_MODE, false).unwrap();
+        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
         assert_eq!(app.dir_listing.selected(), Some(1));
         assert_ne!(app.dir_listing.get(1).name, "..");
 
@@ -926,6 +1042,194 @@ mod tests {
         assert_eq!(dir.display_name(), "data/");
     }
 
+    /// The owner costs a stat that nothing else needs, so it is read only when asked
+    /// for -- which is also what lets a directory be listed without a stat at all.
+    #[test]
+    fn the_owner_is_read_only_when_asked_for() {
+        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+        assert!(!app.dir_listing.options().owners);
+        assert!(
+            app.dir_listing
+                .iter_entries_sorted()
+                .all(|e| e.user.is_none()),
+            "an owner was read without being asked for"
+        );
+
+        app.toggle_owner();
+        assert!(app.show_owner);
+        assert!(app.dir_listing.options().owners);
+        assert!(
+            app.dir_listing
+                .iter_entries_sorted()
+                .all(|e| e.user.is_some()),
+            "asking for the owner did not read it"
+        );
+
+        // A file's size comes from the same stat either way.
+        assert!(
+            app.dir_listing
+                .iter_entries_sorted()
+                .filter(|e| e.kind == EntryKind::File)
+                .all(|e| e.size.is_some()),
+            "a file lost its size"
+        );
+
+        // Hiding it keeps what was already read -- see the toggling test -- and it is
+        // the *next* directory that stops paying, which the following test covers.
+        app.toggle_owner();
+        assert!(!app.show_owner);
+        assert!(
+            app.dir_listing.options().owners,
+            "hiding the column threw away what had been read"
+        );
+    }
+
+    /// A directory is listed without a stat, so everything it shows has to come from
+    /// somewhere else: the xattrs, and readdir for the kind.
+    #[test]
+    fn a_directory_needs_no_stat() {
+        let app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+
+        let dirs: Vec<&DirEntry> = app
+            .dir_listing
+            .iter_entries_sorted()
+            .filter(|e| e.kind == EntryKind::Dir)
+            .collect();
+        assert!(!dirs.is_empty(), "no directories to check");
+
+        for dir in dirs {
+            assert!(
+                dir.name.ends_with('/'),
+                "{} is not marked a directory",
+                dir.name
+            );
+            assert!(dir.user.is_none(), "{} was stat'd anyway", dir.name);
+        }
+    }
+
+    /// Once read, the owner stays read. Hiding the column and showing it again must
+    /// not pay for it twice, however many times it is toggled.
+    #[test]
+    fn showing_the_owner_again_does_not_re_read_it() {
+        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+        app.toggle_owner();
+        assert!(
+            app.dir_listing.options().owners,
+            "the first show did not read"
+        );
+
+        // A value only a re-read would overwrite.
+        app.dir_listing.entries[0].user = Some("sentinel".to_string());
+
+        for _ in 0..3 {
+            app.toggle_owner();
+            app.toggle_owner();
+        }
+
+        assert!(app.show_owner);
+        assert_eq!(
+            app.dir_listing.entries[0].user.as_deref(),
+            Some("sentinel"),
+            "the directory was read again"
+        );
+    }
+
+    /// Leaving with the column hidden should not make the next directory pay for the
+    /// owner, and leaving with it shown should.
+    #[test]
+    fn the_next_directory_follows_the_column() {
+        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+
+        app.cd(&PathBuf::from("src"));
+        assert!(
+            !app.dir_listing.options().owners,
+            "read the owner with the column hidden"
+        );
+
+        app.toggle_owner();
+        app.cd(&PathBuf::from(".."));
+        assert!(
+            app.dir_listing.options().owners,
+            "did not read the owner with the column shown"
+        );
+        assert!(
+            app.dir_listing
+                .iter_entries_sorted()
+                .all(|e| e.user.is_some()),
+            "the owner column is shown but empty"
+        );
+    }
+
+    /// Ordering by owner needs the owner read, whether or not the column is shown.
+    /// Without this the sort silently had nothing to compare.
+    #[test]
+    fn sorting_by_owner_reads_the_owner() {
+        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+        assert!(!app.dir_listing.options().owners);
+
+        app.sort_or_reverse(SortField::Owner.default_mode());
+        assert!(
+            app.dir_listing.options().owners,
+            "sorted by an owner that was never read"
+        );
+        assert!(
+            app.dir_listing
+                .iter_entries_sorted()
+                .all(|e| e.user.is_some()),
+            "the sort had nothing to compare"
+        );
+        assert_eq!(*app.dir_listing.sort_mode().field(), SortField::Owner);
+
+        // And it stays read while that ordering is in effect, even with the column
+        // hidden: the next directory has to sort by it too.
+        assert!(!app.show_owner);
+        app.cd(&PathBuf::from("src"));
+        assert!(
+            app.dir_listing.options().owners,
+            "the next directory sorted by an owner it never read"
+        );
+    }
+
+    /// A directory's recursive time is a third of the round trips, so it is read only
+    /// when wanted -- and, like the owner, kept once read. Asserted on the intent
+    /// rather than the values, since off Ceph there is no rctime to find.
+    #[test]
+    fn showing_the_time_reads_it_once() {
+        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+        assert!(!app.dir_listing.options().times);
+
+        app.toggle_ctime();
+        assert!(app.show_ctime);
+        assert!(
+            app.dir_listing.options().times,
+            "showing the time did not read it"
+        );
+
+        // A value only a re-read would overwrite.
+        app.dir_listing.entries[0].ctime = Some(12_345);
+        for _ in 0..3 {
+            app.toggle_ctime();
+            app.toggle_ctime();
+        }
+        assert_eq!(
+            app.dir_listing.entries[0].ctime,
+            Some(12_345),
+            "the directory was read again"
+        );
+    }
+
+    #[test]
+    fn sorting_by_time_reads_it() {
+        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+
+        app.sort_or_reverse(SortField::CTime.default_mode());
+        assert!(
+            app.dir_listing.options().times,
+            "sorted by a time that was never read"
+        );
+        assert!(!app.show_ctime, "the column was shown as a side effect");
+    }
+
     /// The sort keys and the CLI sort flags share these directions, so they cannot
     /// drift apart.
     #[test]
@@ -959,7 +1263,7 @@ mod tests {
     #[test]
     fn new_honors_the_startup_sort_mode() {
         let mode = SortMode::Normal(SortField::Name);
-        let app = App::new(Some(&PathBuf::from(".")), mode, false).unwrap();
+        let app = App::new(Some(&PathBuf::from(".")), Options::sorted(mode)).unwrap();
         assert_eq!(app.dir_listing.sort_mode(), mode);
 
         let names: Vec<String> = app
@@ -1063,7 +1367,15 @@ mod tests {
             SortField::CTime,
             SortField::Owner,
         ] {
-            let listing = DirListing::from_entries(tied(), false, SortMode::Normal(field), false);
+            let listing = DirListing::from_entries(
+                tied(),
+                false,
+                Options {
+                    sort_mode: SortMode::Normal(field),
+                    dirs_first: false,
+                    ..Options::default()
+                },
+            );
             assert_eq!(
                 displayed(&listing),
                 ["a", "b", "c"],

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ use std::{fs, os::unix::fs::MetadataExt};
 use ratatui::widgets::ListState;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
-use crate::fs::{FSType, get_fs, get_rbytes, get_rctime, get_rentries, id_to_name};
+use crate::fs::{FSType, get_entries, get_fs, get_rbytes, get_rctime, get_rentries, id_to_name};
 use crate::navigation;
 use crate::popup::Popup;
 
@@ -88,6 +88,9 @@ pub struct App {
 pub struct ListingWatch {
     cancel: AtomicBool,
     seen: AtomicUsize,
+    /// How many entries the read expects, from the directory's own entry count;
+    /// zero until known, and stays zero off Ceph.
+    total: AtomicUsize,
 }
 
 impl ListingWatch {
@@ -95,6 +98,7 @@ impl ListingWatch {
         ListingWatch {
             cancel: AtomicBool::new(false),
             seen: AtomicUsize::new(0),
+            total: AtomicUsize::new(0),
         }
     }
 
@@ -112,6 +116,14 @@ impl ListingWatch {
 
     fn seen(&self) -> usize {
         self.seen.load(AtomicOrdering::Relaxed)
+    }
+
+    fn set_total(&self, total: usize) {
+        self.total.store(total, AtomicOrdering::Relaxed);
+    }
+
+    fn total(&self) -> usize {
+        self.total.load(AtomicOrdering::Relaxed)
     }
 }
 
@@ -485,13 +497,19 @@ impl App {
     /// mention -- an ordinary directory change comes and goes without one.
     pub fn progress(&self) -> Option<Message> {
         let pending = self.pending.as_ref()?;
-        (pending.started.elapsed() >= PROGRESS_AFTER).then(|| Message {
-            text: format!(
-                "Reading {:?} ... {} entries (Ctrl-C to cancel)",
-                pending.path,
-                pending.watch.seen()
-            ),
-            kind: MessageKind::Info,
+        (pending.started.elapsed() >= PROGRESS_AFTER).then(|| {
+            // Not every filesystem prices a read upfront; count one-sided there.
+            let entries = match pending.watch.total() {
+                0 => format!("{}", pending.watch.seen()),
+                total => format!("{} / {}", pending.watch.seen(), total),
+            };
+            Message {
+                text: format!(
+                    "Reading {:?} ... {} entries (Ctrl-C to cancel)",
+                    pending.path, entries
+                ),
+                kind: MessageKind::Info,
+            }
         })
     }
 
@@ -936,6 +954,11 @@ fn ls(
         ..*options
     };
     let entry_cwd = DirEntry::from(PathBuf::from(path), EntryKind::Dir, None, &totals);
+    // The directory's own entry count prices the whole read upfront, for the
+    // progress notice. One more constant xattr read per listing, not per entry.
+    if let Some(total) = get_entries(path) {
+        watch.set_total(total);
+    }
     let dir_iterator = fs::read_dir(path)?;
     let mut entries: Vec<DirEntry> = Vec::new();
 
@@ -1616,6 +1639,37 @@ mod tests {
 
         app.pump(&mut listings);
         assert!(app.progress().is_none(), "the notice outlived the read");
+    }
+
+    /// The notice counts one-sided until the directory's own entry count is in
+    /// hand -- off Ceph it never is -- and prices the read against it after. On a
+    /// synthetic watch, so no worker races the assertions.
+    #[test]
+    fn progress_prices_the_read_once_the_total_is_known() {
+        let (mut app, _listings) = App::new(Options::default());
+        let watch = Arc::new(ListingWatch::new());
+        watch.saw_one();
+        watch.saw_one();
+        app.pending = Some(Pending {
+            generation: 0,
+            path: PathBuf::from("/big"),
+            watch: watch.clone(),
+            started: Instant::now() - 2 * PROGRESS_AFTER,
+            on_error: OnError::Message,
+            preserve_message: false,
+        });
+
+        let text = app.progress().unwrap().text;
+        assert!(text.contains("2 entries"), "{}", text);
+        assert!(
+            !text.contains(" / "),
+            "a total appeared from nowhere: {}",
+            text
+        );
+
+        watch.set_total(10_000);
+        let text = app.progress().unwrap().text;
+        assert!(text.contains("2 / 10000 entries"), "{}", text);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -641,8 +641,168 @@ mod tests {
         }
     }
 
+    /// Ascending by size: small, medium, large.
+    fn listing(has_dotdot: bool, sort_mode: SortMode) -> DirListing {
+        DirListing::from_entries(
+            vec![
+                entry("large", 300),
+                entry("small", 100),
+                entry("medium", 200),
+            ],
+            has_dotdot,
+            sort_mode,
+        )
+    }
+
     fn displayed(listing: &DirListing) -> Vec<String> {
         listing.iter_entries().map(|e| e.name.clone()).collect()
+    }
+
+    /// `get()` maps a selection index to what the same index displays. This is the
+    /// pairing that the reversal and the ".." offset can each break.
+    fn assert_get_matches_display(listing: &DirListing) {
+        let names = displayed(listing);
+        assert_eq!(names.len(), listing.len());
+        for (i, name) in names.iter().enumerate() {
+            assert_eq!(&listing.get(i).name, name, "get({}) disagrees", i);
+        }
+    }
+
+    #[test]
+    fn display_order_follows_direction() {
+        let normal = listing(false, SortMode::Normal(SortField::Size));
+        assert_eq!(displayed(&normal), ["small", "medium", "large"]);
+
+        let reversed = listing(false, SortMode::Reversed(SortField::Size));
+        assert_eq!(displayed(&reversed), ["large", "medium", "small"]);
+    }
+
+    #[test]
+    fn dotdot_displays_first_in_both_directions() {
+        for sort_mode in [
+            SortMode::Normal(SortField::Size),
+            SortMode::Reversed(SortField::Size),
+        ] {
+            let listing = listing(true, sort_mode);
+            assert_eq!(displayed(&listing)[0], "..");
+            assert_eq!(listing.len(), 4);
+        }
+    }
+
+    #[test]
+    fn get_agrees_with_display_order() {
+        for has_dotdot in [false, true] {
+            for field in [SortField::Name, SortField::Size, SortField::Rentries] {
+                for sort_mode in [SortMode::Normal(field), SortMode::Reversed(field)] {
+                    assert_get_matches_display(&listing(has_dotdot, sort_mode));
+                }
+            }
+        }
+    }
+
+    /// Reversing must flip the display without disturbing the stored order, and
+    /// `get()` has to keep up.
+    #[test]
+    fn reversing_in_place_keeps_get_consistent() {
+        let mut listing = listing(true, SortMode::Normal(SortField::Size));
+        assert_eq!(displayed(&listing), ["..", "small", "medium", "large"]);
+        assert_get_matches_display(&listing);
+
+        listing.sort(SortMode::Reversed(SortField::Size));
+        assert_eq!(displayed(&listing), ["..", "large", "medium", "small"]);
+        assert_get_matches_display(&listing);
+    }
+
+    #[test]
+    fn selection_is_clamped_to_the_listing() {
+        let mut listing = listing(true, DEFAULT_SORT_MODE);
+
+        listing.select_last();
+        assert_eq!(listing.selected(), Some(3));
+        listing.select_next(1);
+        assert_eq!(listing.selected(), Some(3), "ran off the end");
+        listing.select_next(100);
+        assert_eq!(listing.selected(), Some(3), "ran off the end");
+
+        listing.select_prev(100);
+        assert_eq!(listing.selected(), Some(0), "ran off the start");
+
+        assert_eq!(listing.saturating_select(2), 2);
+        assert_eq!(listing.saturating_select(99), 3);
+    }
+
+    /// An empty directory still has "..", and must not be indexed out of bounds.
+    #[test]
+    fn empty_listing_has_only_dotdot() {
+        let mut listing = DirListing::from_entries(vec![], true, DEFAULT_SORT_MODE);
+        assert_eq!(displayed(&listing), [".."]);
+        assert_get_matches_display(&listing);
+
+        listing.select_last();
+        listing.select_next(1);
+        assert_eq!(listing.selected(), Some(0));
+    }
+
+    #[test]
+    fn select_by_name_uses_display_indices() {
+        let mut listing = listing(true, SortMode::Reversed(SortField::Size));
+
+        assert_eq!(listing.select_by_name("large"), Some(1));
+        assert_eq!(listing.selected(), Some(1));
+        assert_eq!(listing.get(1).name, "large");
+
+        assert_eq!(listing.select_by_name(".."), Some(0));
+        assert_eq!(listing.select_by_name("nonexistent"), None);
+        assert_eq!(
+            listing.selected(),
+            Some(0),
+            "failed lookup moved the cursor"
+        );
+    }
+
+    #[test]
+    fn arriving_selects_the_first_real_entry() {
+        let mut listing = listing(true, DEFAULT_SORT_MODE);
+
+        listing.select_first_entry();
+        assert_eq!(listing.selected(), Some(1));
+        assert_ne!(listing.get(1).name, "..");
+    }
+
+    /// ".." is the only thing left to select in an empty directory.
+    #[test]
+    fn arriving_in_an_empty_directory_selects_dotdot() {
+        let mut listing = DirListing::from_entries(vec![], true, DEFAULT_SORT_MODE);
+        listing.select_first_entry();
+        assert_eq!(listing.selected(), Some(0));
+        assert_eq!(listing.get(0).name, "..");
+    }
+
+    /// The root has no "..", so its first entry is at index 0.
+    #[test]
+    fn arriving_without_dotdot_selects_index_zero() {
+        let mut listing = listing(false, DEFAULT_SORT_MODE);
+        listing.select_first_entry();
+        assert_eq!(listing.selected(), Some(0));
+    }
+
+    /// Entering a directory skips "..", but returning to one restores what was
+    /// highlighted there. Uses the crate's own tree, which cargo makes the cwd.
+    #[test]
+    fn cd_selects_the_first_real_entry_then_remembers() {
+        let mut app = App::new(Some(&PathBuf::from("."))).unwrap();
+        assert_eq!(app.dir_listing.selected(), Some(1));
+        assert_ne!(app.dir_listing.get(1).name, "..");
+
+        app.dir_listing
+            .select_by_name("src/")
+            .expect("src/ should be listed");
+        app.cd(&PathBuf::from("src"));
+        assert_eq!(app.dir_listing.selected(), Some(1), "did not skip '..'");
+
+        app.cd(&PathBuf::from(".."));
+        let selected = app.dir_listing.selected().unwrap();
+        assert_eq!(app.dir_listing.get(selected).name, "src/");
     }
 
     /// Names break ties so that the listing doesn't depend on readdir order.

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use crate::fs::{FSType, get_fs, get_rbytes, get_rctime, get_rentries, id_to_name
 use crate::navigation;
 use crate::popup::Popup;
 
-const DEFAULT_SORT_MODE: SortMode = SortMode::Reversed(SortField::Size);
+pub const DEFAULT_SORT_MODE: SortMode = SortMode::Reversed(SortField::Size);
 
 pub struct App {
     pub should_exit: bool,
@@ -323,21 +323,9 @@ impl DirListing {
         sort(&mut entries, sort_mode);
 
         let has_parent = *path != *"/";
-        let dotdot = has_parent.then(|| DirEntry {
-            name: "..".to_string(),
-            kind: EntryKind::Dir,
-            size: None,
-            rentries: None,
-            ctime: None,
-            user: None,
-            group: None,
-        });
+        let dotdot = has_parent.then(dotdot_entry);
 
-        let (max_rentries, max_size) = entries.iter().fold((0, 0), |(max_r, max_s), entry| {
-            let r = entry.rentries.unwrap_or(0);
-            let s = entry.size.unwrap_or(0);
-            (max_r.max(r), max_s.max(s))
-        });
+        let (max_rentries, max_size) = max_stats(&entries);
         // Note a possible consistency check we're not using here:
         // that the sum of the entry sizes add up to the cwd's r-sizes.
         let total_rentries = entry_cwd.rentries.unwrap_or(0);
@@ -364,6 +352,32 @@ impl DirListing {
             },
             fs,
         })
+    }
+
+    /// Build a listing from entries that didn't come from a filesystem.
+    #[cfg(test)]
+    pub fn from_entries(
+        mut entries: Vec<DirEntry>,
+        has_dotdot: bool,
+        sort_mode: SortMode,
+    ) -> DirListing {
+        sort(&mut entries, sort_mode);
+
+        let (max_rentries, max_size) = max_stats(&entries);
+
+        DirListing {
+            dotdot: has_dotdot.then(dotdot_entry),
+            stats: ListingStats {
+                max_rentries,
+                total_rentries: entries.iter().filter_map(|e| e.rentries).sum(),
+                max_size,
+                total_size: entries.iter().filter_map(|e| e.size).sum(),
+            },
+            entries,
+            state: ListState::default().with_selected(Some(0)),
+            sort_mode,
+            fs: None,
+        }
     }
 
     fn default() -> DirListing {
@@ -523,21 +537,59 @@ impl DirListing {
     }
 }
 
+/// The synthetic ".." entry, which has no stat of its own.
+fn dotdot_entry() -> DirEntry {
+    DirEntry {
+        name: "..".to_string(),
+        kind: EntryKind::Dir,
+        size: None,
+        rentries: None,
+        ctime: None,
+        user: None,
+        group: None,
+    }
+}
+
+/// The largest size and rentries in the listing, which set the gauge scales.
+fn max_stats(entries: &[DirEntry]) -> (usize, usize) {
+    entries.iter().fold((0, 0), |(max_r, max_s), entry| {
+        let r = entry.rentries.unwrap_or(0);
+        let s = entry.size.unwrap_or(0);
+        (max_r.max(r), max_s.max(s))
+    })
+}
+
 fn sort(entries: &mut [DirEntry], sort_mode: SortMode) {
+    // Every comparison ends on the name, which is unique within a directory. That
+    // makes the order total, so the listing doesn't depend on readdir order.
+    let by_name = |a: &DirEntry, b: &DirEntry| a.name.cmp(&b.name);
+
     match sort_mode.field() {
-        SortField::Name => entries.sort_by(|a, b| a.name.cmp(&b.name).then(a.size.cmp(&b.size))),
-        SortField::Size => {
-            entries.sort_by(|a, b| a.size.cmp(&b.size).then(a.rentries.cmp(&b.rentries)))
-        }
-        SortField::Rentries => {
-            entries.sort_by(|a, b| a.rentries.cmp(&b.rentries).then(a.size.cmp(&b.size)))
-        }
-        SortField::CTime => entries.sort_by(|a, b| a.ctime.cmp(&b.ctime).then(a.size.cmp(&b.size))),
+        SortField::Name => entries.sort_by(by_name),
+        SortField::Size => entries.sort_by(|a, b| {
+            a.size
+                .cmp(&b.size)
+                .then(a.rentries.cmp(&b.rentries))
+                .then(by_name(a, b))
+        }),
+        SortField::Rentries => entries.sort_by(|a, b| {
+            a.rentries
+                .cmp(&b.rentries)
+                .then(a.size.cmp(&b.size))
+                .then(by_name(a, b))
+        }),
+        SortField::CTime => entries.sort_by(|a, b| {
+            a.ctime
+                .cmp(&b.ctime)
+                .then(a.size.cmp(&b.size))
+                .then(by_name(a, b))
+        }),
         SortField::Owner => entries.sort_by(|a, b| {
             a.user
                 .cmp(&b.user)
                 .then(a.group.cmp(&b.group))
                 .then(a.size.cmp(&b.size))
+                .then(by_name(a, b))
         }),
     }
 }
@@ -571,4 +623,46 @@ fn ls(path: &PathBuf) -> Result<(DirEntry, Vec<DirEntry>), std::io::Error> {
     }
 
     Ok((entry_cwd, entries))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(name: &str, size: usize) -> DirEntry {
+        DirEntry {
+            name: name.to_string(),
+            kind: EntryKind::Dir,
+            size: Some(size),
+            rentries: Some(size),
+            ctime: Some(size),
+            user: Some("alice".to_string()),
+            group: Some("scc".to_string()),
+        }
+    }
+
+    fn displayed(listing: &DirListing) -> Vec<String> {
+        listing.iter_entries().map(|e| e.name.clone()).collect()
+    }
+
+    /// Names break ties so that the listing doesn't depend on readdir order.
+    #[test]
+    fn equal_entries_are_ordered_by_name() {
+        let tied = || vec![entry("c", 1), entry("a", 1), entry("b", 1)];
+
+        for field in [
+            SortField::Size,
+            SortField::Rentries,
+            SortField::CTime,
+            SortField::Owner,
+        ] {
+            let listing = DirListing::from_entries(tied(), false, SortMode::Normal(field));
+            assert_eq!(
+                displayed(&listing),
+                ["a", "b", "c"],
+                "{:?} is unstable",
+                field
+            );
+        }
+    }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,6 +23,8 @@ pub struct App {
     pub popup: Option<Popup>,
     pub show_owner: bool,
     pub show_ctime: bool,
+    /// Show sizes and counts in full instead of scaled to a unit.
+    pub exact: bool,
     pub message: Option<Message>,
     highlighted: HashMap<PathBuf, (String, usize)>,
 }
@@ -216,6 +218,7 @@ impl App {
             popup: None,
             show_owner: false,
             show_ctime: false,
+            exact: false,
             message: None,
             highlighted: HashMap::new(),
         };

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use crate::fs::{FSType, get_fs, get_rbytes, get_rctime, get_rentries, id_to_name
 use crate::navigation;
 use crate::popup::Popup;
 
-pub const DEFAULT_SORT_MODE: SortMode = SortMode::Reversed(SortField::Size);
+pub const DEFAULT_SORT_MODE: SortMode = SortField::Size.default_mode();
 
 pub struct App {
     pub should_exit: bool,
@@ -133,6 +133,17 @@ pub enum SortField {
     CTime,
 }
 
+impl SortField {
+    /// The direction a field starts in when it is first chosen, by key or by flag.
+    /// Sizes, counts and times read most-first; names and owners read ascending.
+    pub const fn default_mode(self) -> SortMode {
+        match self {
+            SortField::Name | SortField::Owner => SortMode::Normal(self),
+            SortField::Size | SortField::Rentries | SortField::CTime => SortMode::Reversed(self),
+        }
+    }
+}
+
 impl SortMode {
     pub fn field(&self) -> &SortField {
         match self {
@@ -171,14 +182,14 @@ pub enum MessageKind {
 }
 
 impl App {
-    pub fn new(cwd: Option<&PathBuf>) -> Result<App, std::io::Error> {
+    pub fn new(cwd: Option<&PathBuf>, sort_mode: SortMode) -> Result<App, std::io::Error> {
         let cwd: PathBuf = if let Some(cwd) = cwd {
             cwd.clone()
         } else {
             std::env::current_dir()?
         };
 
-        let dir_listing = DirListing::default();
+        let dir_listing = DirListing::empty(sort_mode);
         let original_cwd = cwd.clone();
         let mut app = App {
             should_exit: false,
@@ -380,12 +391,12 @@ impl DirListing {
         }
     }
 
-    fn default() -> DirListing {
+    fn empty(sort_mode: SortMode) -> DirListing {
         DirListing {
             dotdot: None,
             entries: Vec::new(),
             state: ListState::default(),
-            sort_mode: DEFAULT_SORT_MODE,
+            sort_mode,
             stats: ListingStats {
                 max_rentries: 0,
                 total_rentries: 0,
@@ -794,7 +805,7 @@ mod tests {
     /// highlighted there. Uses the crate's own tree, which cargo makes the cwd.
     #[test]
     fn cd_selects_the_first_real_entry_then_remembers() {
-        let mut app = App::new(Some(&PathBuf::from("."))).unwrap();
+        let mut app = App::new(Some(&PathBuf::from(".")), DEFAULT_SORT_MODE).unwrap();
         assert_eq!(app.dir_listing.selected(), Some(1));
         assert_ne!(app.dir_listing.get(1).name, "..");
 
@@ -807,6 +818,52 @@ mod tests {
         app.cd(&PathBuf::from(".."));
         let selected = app.dir_listing.selected().unwrap();
         assert_eq!(app.dir_listing.get(selected).name, "src/");
+    }
+
+    /// The sort keys and the CLI sort flags share these directions, so they cannot
+    /// drift apart.
+    #[test]
+    fn sort_fields_have_natural_directions() {
+        for field in [SortField::Name, SortField::Owner] {
+            assert!(
+                !field.default_mode().is_reversed(),
+                "{:?} should read ascending",
+                field
+            );
+        }
+        for field in [SortField::Size, SortField::Rentries, SortField::CTime] {
+            assert!(
+                field.default_mode().is_reversed(),
+                "{:?} should read most-first",
+                field
+            );
+        }
+        for field in [
+            SortField::Name,
+            SortField::Size,
+            SortField::Rentries,
+            SortField::Owner,
+            SortField::CTime,
+        ] {
+            assert_eq!(*field.default_mode().field(), field);
+        }
+    }
+
+    /// A startup sort mode has to reach the listing App::new builds.
+    #[test]
+    fn new_honors_the_startup_sort_mode() {
+        let mode = SortMode::Normal(SortField::Name);
+        let app = App::new(Some(&PathBuf::from(".")), mode).unwrap();
+        assert_eq!(app.dir_listing.sort_mode(), mode);
+
+        let names: Vec<String> = app
+            .dir_listing
+            .iter_entries_sorted()
+            .map(|e| e.name.clone())
+            .collect();
+        let mut ascending = names.clone();
+        ascending.sort();
+        assert_eq!(names, ascending, "listing is not in name order");
     }
 
     /// Names break ties so that the listing doesn't depend on readdir order.

--- a/src/app.rs
+++ b/src/app.rs
@@ -299,7 +299,7 @@ impl App {
                 self.dir_listing.saturating_select(*idx);
             }
         } else {
-            self.dir_listing.select_first();
+            self.dir_listing.select_first_entry();
         }
     }
 }
@@ -466,6 +466,18 @@ impl DirListing {
 
     pub fn select_first(&mut self) {
         self.state.select(Some(0));
+    }
+
+    /// Select the first entry that isn't "..", which is what a directory being
+    /// entered should land on. Falls back to ".." when there is nothing else.
+    pub fn select_first_entry(&mut self) {
+        let dotdot_only = self.entries.is_empty();
+        let first = if self.dotdot.is_some() && !dotdot_only {
+            1
+        } else {
+            0
+        };
+        self.state.select(Some(first));
     }
 
     pub fn select_last(&mut self) {

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -142,6 +142,7 @@ mod tests {
             ],
             true,
             SortMode::Reversed(SortField::Size),
+            false,
         )
     }
 
@@ -183,6 +184,7 @@ mod tests {
             }],
             false,
             SortMode::Reversed(SortField::Size),
+            false,
         );
         assert_eq!(
             render(&listing, &Format::Parseable),

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use crate::app::{DirEntry, DirListing};
-use crate::format::{CTIME_FMT_WIDTH, ctime_str, rentries_str, size_str};
+use crate::format::{CTIME_FMT_WIDTH, Numbers, ctime_str};
 
 /// Stands in for a value the filesystem didn't give us, so that every row has the
 /// same number of fields.
@@ -14,8 +14,10 @@ pub enum Format {
     /// Tab-separated raw values: bytes, entry count, ctime as Unix seconds.
     /// Deliberately independent of whether stdout is a terminal.
     Parseable,
-    /// Aligned columns with the same units the TUI shows.
-    Human,
+    /// Aligned columns with the same units the TUI shows. `exact` shows sizes and
+    /// counts in full instead; the parseable format is always exact, so it has
+    /// nothing to switch.
+    Human { exact: bool },
 }
 
 pub fn write_listing(
@@ -29,7 +31,9 @@ pub fn write_listing(
 
     match format {
         Format::Parseable => write_parseable(&entries, out),
-        Format::Human => write_human(&entries, current_year, out),
+        Format::Human { exact } => {
+            write_human(&entries, current_year, Numbers::from_exact(*exact), out)
+        }
     }
 }
 
@@ -55,6 +59,7 @@ fn write_parseable(entries: &[&DirEntry], out: &mut impl Write) -> std::io::Resu
 fn write_human(
     entries: &[&DirEntry],
     current_year: isize,
+    numbers: Numbers,
     out: &mut impl Write,
 ) -> std::io::Result<()> {
     let width = |f: &dyn Fn(&DirEntry) -> String| -> usize {
@@ -62,11 +67,11 @@ fn write_human(
     };
 
     let size = |e: &DirEntry| match e.size {
-        Some(_) => size_str(e.size, true),
+        Some(_) => numbers.size(e.size, true),
         None => MISSING.to_string(),
     };
     let rentries = |e: &DirEntry| match e.rentries {
-        Some(_) => rentries_str(e.rentries, true),
+        Some(_) => numbers.count(e.rentries, true),
         None => MISSING.to_string(),
     };
     let owner = |e: &DirEntry| {
@@ -166,7 +171,7 @@ mod tests {
     /// ".." exists in the listing but must never be printed.
     #[test]
     fn dotdot_is_omitted() {
-        for format in [Format::Parseable, Format::Human] {
+        for format in [Format::Parseable, Format::Human { exact: false }] {
             let out = render(&listing(), &format);
             assert!(!out.contains(".."), "{:?} leaked '..'", out);
             assert_eq!(out.lines().count(), 3);
@@ -194,7 +199,7 @@ mod tests {
 
     #[test]
     fn human_columns_are_aligned() {
-        let out = render(&listing(), &Format::Human);
+        let out = render(&listing(), &Format::Human { exact: false });
         let lines: Vec<&str> = out.lines().collect();
 
         // Every row has to agree on where the name column starts.
@@ -213,6 +218,33 @@ mod tests {
         assert!(lines[0].contains("48.2 K"), "{}", lines[0]);
         assert!(lines[0].contains("2001"), "{}", lines[0]);
         assert!(lines[0].contains("alice:scc"), "{}", lines[0]);
+    }
+
+    /// Exact numbers, but still the aligned human layout rather than the parseable
+    /// one.
+    #[test]
+    fn human_exact_shows_values_in_full() {
+        let out = render(&listing(), &Format::Human { exact: true });
+        let lines: Vec<&str> = out.lines().collect();
+
+        assert!(lines[0].contains("1099511627776"), "{}", lines[0]);
+        assert!(lines[0].contains("48213"), "{}", lines[0]);
+        assert!(!lines[0].contains("1.1 TB"), "{}", lines[0]);
+
+        assert!(!out.contains('\t'), "fell back to the parseable format");
+        assert!(lines[0].contains("2001"), "{}", lines[0]);
+        assert!(lines[0].contains("alice:scc"), "{}", lines[0]);
+
+        let name_starts: Vec<usize> = lines
+            .iter()
+            .zip(["data/", "bigfile.h5", "notes.txt"])
+            .map(|(line, name)| line.rfind(name).unwrap())
+            .collect();
+        assert!(
+            name_starts.windows(2).all(|w| w[0] == w[1]),
+            "ragged name column in\n{}",
+            out
+        );
     }
 
     /// Display order follows the sort mode, and reversal must not be re-sorted in.

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -165,6 +165,7 @@ mod tests {
                 // with both.
                 owners: true,
                 times: true,
+                jobs: 1,
             },
         )
     }
@@ -213,6 +214,7 @@ mod tests {
                 // with both.
                 owners: true,
                 times: true,
+                jobs: 1,
             },
         );
         assert_eq!(
@@ -288,6 +290,7 @@ mod tests {
                 // with both.
                 owners: true,
                 times: true,
+                jobs: 1,
             },
         );
 

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -99,7 +99,7 @@ fn write_human(
             rentries(entry),
             ctime,
             owner(entry),
-            entry.name,
+            entry.display_name(),
             swidth = size_width,
             rwidth = rentries_width,
             cwidth = CTIME_FMT_WIDTH,
@@ -245,6 +245,29 @@ mod tests {
             "ragged name column in\n{}",
             out
         );
+    }
+
+    /// The human format marks a symlink; the parseable one must not, since a name may
+    /// contain `@` and a parser has no way to tell a mark from a character.
+    #[test]
+    fn only_the_human_format_marks_symlinks() {
+        let listing = DirListing::from_entries(
+            vec![
+                entry("link", EntryKind::Symlink, Some(8), None),
+                entry("plain", EntryKind::File, Some(9), None),
+            ],
+            false,
+            SortMode::Reversed(SortField::Size),
+            false,
+        );
+
+        let human = render(&listing, &Format::Human { exact: false });
+        assert!(human.contains("link@"), "{}", human);
+        assert!(!human.contains("plain@"), "{}", human);
+
+        let parseable = render(&listing, &Format::Parseable);
+        assert!(!parseable.contains('@'), "{}", parseable);
+        assert!(parseable.contains("\tlink\n"), "{}", parseable);
     }
 
     /// Display order follows the sort mode, and reversal must not be re-sorted in.

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1,0 +1,235 @@
+use std::io::Write;
+
+use crate::app::{DirEntry, DirListing};
+use crate::format::{CTIME_FMT_WIDTH, ctime_str, rentries_str, size_str};
+
+/// Stands in for a value the filesystem didn't give us, so that every row has the
+/// same number of fields.
+const MISSING: &str = "-";
+
+/// Flat mode always emits every column. The TUI hides owner and time because
+/// terminal width is scarce, but a pipe has no width limit, and a fixed column
+/// set is what makes the output parsable without flag-dependent field offsets.
+pub enum Format {
+    /// Tab-separated raw values: bytes, entry count, ctime as Unix seconds.
+    /// Deliberately independent of whether stdout is a terminal.
+    Parseable,
+    /// Aligned columns with the same units the TUI shows.
+    Human,
+}
+
+pub fn write_listing(
+    listing: &DirListing,
+    format: &Format,
+    current_year: isize,
+    out: &mut impl Write,
+) -> std::io::Result<()> {
+    // ".." is deliberately omitted: it isn't part of this directory's contents.
+    let entries: Vec<&DirEntry> = listing.iter_entries_sorted().collect();
+
+    match format {
+        Format::Parseable => write_parseable(&entries, out),
+        Format::Human => write_human(&entries, current_year, out),
+    }
+}
+
+fn write_parseable(entries: &[&DirEntry], out: &mut impl Write) -> std::io::Result<()> {
+    for entry in entries {
+        let num = |v: Option<usize>| v.map_or(MISSING.to_string(), |v| v.to_string());
+        let text = |v: &Option<String>| v.clone().unwrap_or(MISSING.to_string());
+
+        writeln!(
+            out,
+            "{}\t{}\t{}\t{}\t{}\t{}",
+            num(entry.size),
+            num(entry.rentries),
+            num(entry.ctime),
+            text(&entry.user),
+            text(&entry.group),
+            entry.name,
+        )?;
+    }
+    Ok(())
+}
+
+fn write_human(
+    entries: &[&DirEntry],
+    current_year: isize,
+    out: &mut impl Write,
+) -> std::io::Result<()> {
+    let width = |f: &dyn Fn(&DirEntry) -> String| -> usize {
+        entries.iter().map(|e| f(e).len()).max().unwrap_or(0)
+    };
+
+    let size = |e: &DirEntry| match e.size {
+        Some(_) => size_str(e.size, true),
+        None => MISSING.to_string(),
+    };
+    let rentries = |e: &DirEntry| match e.rentries {
+        Some(_) => rentries_str(e.rentries, true),
+        None => MISSING.to_string(),
+    };
+    let owner = |e: &DirEntry| {
+        format!(
+            "{}:{}",
+            e.user.clone().unwrap_or(MISSING.to_string()),
+            e.group.clone().unwrap_or(MISSING.to_string())
+        )
+    };
+
+    let size_width = width(&size);
+    let rentries_width = width(&rentries);
+    let owner_width = width(&owner);
+
+    for entry in entries {
+        let ctime = entry
+            .ctime
+            .map(|c| ctime_str(c, current_year))
+            .unwrap_or(MISSING.to_string());
+
+        writeln!(
+            out,
+            "{:>swidth$}  {:>rwidth$}  {:>cwidth$}  {:<owidth$}  {}",
+            size(entry),
+            rentries(entry),
+            ctime,
+            owner(entry),
+            entry.name,
+            swidth = size_width,
+            rwidth = rentries_width,
+            cwidth = CTIME_FMT_WIDTH,
+            owidth = owner_width,
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{EntryKind, SortField, SortMode};
+
+    fn entry(
+        name: &str,
+        kind: EntryKind,
+        size: Option<usize>,
+        rentries: Option<usize>,
+    ) -> DirEntry {
+        DirEntry {
+            name: name.to_string(),
+            kind,
+            size,
+            rentries,
+            // 2001-06-15T12:00:00Z: mid-year, so the year is timezone-independent,
+            // and old enough to exercise the year-showing branch of the format
+            ctime: Some(992_606_400),
+            user: Some("alice".to_string()),
+            group: Some("scc".to_string()),
+        }
+    }
+
+    fn listing() -> DirListing {
+        DirListing::from_entries(
+            vec![
+                entry(
+                    "data/",
+                    EntryKind::Dir,
+                    Some(1_099_511_627_776),
+                    Some(48_213),
+                ),
+                entry("bigfile.h5", EntryKind::File, Some(2_147_483_648), None),
+                entry("notes.txt", EntryKind::File, Some(120), None),
+            ],
+            true,
+            SortMode::Reversed(SortField::Size),
+        )
+    }
+
+    fn render(listing: &DirListing, format: &Format) -> String {
+        let mut buf: Vec<u8> = Vec::new();
+        write_listing(listing, format, 2026, &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn parseable_is_tab_separated_with_six_fields() {
+        let out = render(&listing(), &Format::Parseable);
+        assert_eq!(
+            out,
+            "1099511627776\t48213\t992606400\talice\tscc\tdata/\n\
+             2147483648\t-\t992606400\talice\tscc\tbigfile.h5\n\
+             120\t-\t992606400\talice\tscc\tnotes.txt\n"
+        );
+    }
+
+    /// ".." exists in the listing but must never be printed.
+    #[test]
+    fn dotdot_is_omitted() {
+        for format in [Format::Parseable, Format::Human] {
+            let out = render(&listing(), &format);
+            assert!(!out.contains(".."), "{:?} leaked '..'", out);
+            assert_eq!(out.lines().count(), 3);
+        }
+    }
+
+    #[test]
+    fn parseable_survives_missing_values() {
+        let listing = DirListing::from_entries(
+            vec![DirEntry {
+                user: None,
+                group: None,
+                ctime: None,
+                ..entry("opaque/", EntryKind::Dir, None, None)
+            }],
+            false,
+            SortMode::Reversed(SortField::Size),
+        );
+        assert_eq!(
+            render(&listing, &Format::Parseable),
+            "-\t-\t-\t-\t-\topaque/\n"
+        );
+    }
+
+    #[test]
+    fn human_columns_are_aligned() {
+        let out = render(&listing(), &Format::Human);
+        let lines: Vec<&str> = out.lines().collect();
+
+        // Every row has to agree on where the name column starts.
+        let name_starts: Vec<usize> = lines
+            .iter()
+            .zip(["data/", "bigfile.h5", "notes.txt"])
+            .map(|(line, name)| line.rfind(name).unwrap())
+            .collect();
+        assert!(
+            name_starts.windows(2).all(|w| w[0] == w[1]),
+            "ragged name column in\n{}",
+            out
+        );
+
+        assert!(lines[0].contains("1.1 TB"), "{}", lines[0]);
+        assert!(lines[0].contains("48.2 K"), "{}", lines[0]);
+        assert!(lines[0].contains("2001"), "{}", lines[0]);
+        assert!(lines[0].contains("alice:scc"), "{}", lines[0]);
+    }
+
+    /// Display order follows the sort mode, and reversal must not be re-sorted in.
+    #[test]
+    fn respects_sort_mode() {
+        let mut listing = listing();
+
+        listing.sort(SortMode::Normal(SortField::Size));
+        let names: Vec<String> = render(&listing, &Format::Parseable)
+            .lines()
+            .map(|l| l.rsplit('\t').next().unwrap().to_string())
+            .collect();
+        assert_eq!(names, ["notes.txt", "bigfile.h5", "data/"]);
+
+        listing.sort(SortMode::Normal(SortField::Name));
+        let names: Vec<String> = render(&listing, &Format::Parseable)
+            .lines()
+            .map(|l| l.rsplit('\t').next().unwrap().to_string())
+            .collect();
+        assert_eq!(names, ["bigfile.h5", "data/", "notes.txt"]);
+    }
+}

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -31,9 +31,13 @@ pub fn write_listing(
 
     match format {
         Format::Parseable => write_parseable(&entries, out),
-        Format::Human { exact } => {
-            write_human(&entries, current_year, Numbers::from_exact(*exact), out)
-        }
+        Format::Human { exact } => write_human(
+            &entries,
+            current_year,
+            Numbers::from_exact(*exact),
+            listing.options().owners,
+            out,
+        ),
     }
 }
 
@@ -60,6 +64,7 @@ fn write_human(
     entries: &[&DirEntry],
     current_year: isize,
     numbers: Numbers,
+    owners: bool,
     out: &mut impl Write,
 ) -> std::io::Result<()> {
     let width = |f: &dyn Fn(&DirEntry) -> String| -> usize {
@@ -84,7 +89,9 @@ fn write_human(
 
     let size_width = width(&size);
     let rentries_width = width(&rentries);
-    let owner_width = width(&owner);
+    // Omitted rather than filled with placeholders when it wasn't read: this format
+    // is for reading, and a column of dashes says nothing.
+    let owner_width = if owners { width(&owner) } else { 0 };
 
     for entry in entries {
         let ctime = entry
@@ -92,18 +99,23 @@ fn write_human(
             .map(|c| ctime_str(c, current_year))
             .unwrap_or(MISSING.to_string());
 
+        let owner = if owners {
+            format!("  {:<width$}", owner(entry), width = owner_width)
+        } else {
+            String::new()
+        };
+
         writeln!(
             out,
-            "{:>swidth$}  {:>rwidth$}  {:>cwidth$}  {:<owidth$}  {}",
+            "{:>swidth$}  {:>rwidth$}  {:>cwidth$}{}  {}",
             size(entry),
             rentries(entry),
             ctime,
-            owner(entry),
+            owner,
             entry.display_name(),
             swidth = size_width,
             rwidth = rentries_width,
             cwidth = CTIME_FMT_WIDTH,
-            owidth = owner_width,
         )?;
     }
     Ok(())
@@ -112,7 +124,7 @@ fn write_human(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{EntryKind, SortField, SortMode};
+    use crate::app::{EntryKind, Options, SortField, SortMode};
 
     fn entry(
         name: &str,
@@ -146,8 +158,14 @@ mod tests {
                 entry("notes.txt", EntryKind::File, Some(120), None),
             ],
             true,
-            SortMode::Reversed(SortField::Size),
-            false,
+            Options {
+                sort_mode: SortMode::Reversed(SortField::Size),
+                dirs_first: false,
+                // These entries carry owners and times, so the listing was read
+                // with both.
+                owners: true,
+                times: true,
+            },
         )
     }
 
@@ -188,8 +206,14 @@ mod tests {
                 ..entry("opaque/", EntryKind::Dir, None, None)
             }],
             false,
-            SortMode::Reversed(SortField::Size),
-            false,
+            Options {
+                sort_mode: SortMode::Reversed(SortField::Size),
+                dirs_first: false,
+                // These entries carry owners and times, so the listing was read
+                // with both.
+                owners: true,
+                times: true,
+            },
         );
         assert_eq!(
             render(&listing, &Format::Parseable),
@@ -257,8 +281,14 @@ mod tests {
                 entry("plain", EntryKind::File, Some(9), None),
             ],
             false,
-            SortMode::Reversed(SortField::Size),
-            false,
+            Options {
+                sort_mode: SortMode::Reversed(SortField::Size),
+                dirs_first: false,
+                // These entries carry owners and times, so the listing was read
+                // with both.
+                owners: true,
+                times: true,
+            },
         );
 
         let human = render(&listing, &Format::Human { exact: false });
@@ -268,6 +298,49 @@ mod tests {
         let parseable = render(&listing, &Format::Parseable);
         assert!(!parseable.contains('@'), "{}", parseable);
         assert!(parseable.contains("\tlink\n"), "{}", parseable);
+    }
+
+    /// The owner column appears only when it was read. The human format drops it
+    /// rather than filling it with placeholders; the parseable one keeps its six
+    /// fields and marks them unavailable, so field offsets never move.
+    #[test]
+    fn the_owner_column_appears_only_when_it_was_read() {
+        let unread = DirListing::from_entries(
+            vec![DirEntry {
+                user: None,
+                group: None,
+                ..entry("notes.txt", EntryKind::File, Some(120), None)
+            }],
+            false,
+            Options::default(),
+        );
+        let read = DirListing::from_entries(
+            vec![entry("notes.txt", EntryKind::File, Some(120), None)],
+            false,
+            Options {
+                owners: true,
+                ..Options::default()
+            },
+        );
+
+        let human_unread = render(&unread, &Format::Human { exact: false });
+        let human_read = render(&read, &Format::Human { exact: false });
+        assert!(human_read.contains("alice:scc"), "{}", human_read);
+        assert!(!human_unread.contains("alice"), "{}", human_unread);
+        assert!(
+            human_unread.len() < human_read.len(),
+            "the column was not dropped: {:?}",
+            human_unread
+        );
+
+        for listing in [&unread, &read] {
+            let out = render(listing, &Format::Parseable);
+            assert_eq!(out.trim_end().split('\t').count(), 6, "{}", out);
+        }
+        assert!(
+            render(&unread, &Format::Parseable).contains("\t-\t-\t"),
+            "the unread owner is not marked"
+        );
     }
 
     /// Display order follows the sort mode, and reversal must not be re-sorted in.

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -142,6 +142,8 @@ mod tests {
             ctime: Some(992_606_400),
             user: Some("alice".to_string()),
             group: Some("scc".to_string()),
+            uid: None,
+            gid: None,
         }
     }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,71 @@
+use chrono::{DateTime, Datelike, Local};
+
+/// Width of the strings returned by [`ctime_str`]:
+/// 'Jan  1  2000' or 'Dec 31 12:34'
+pub const CTIME_FMT_WIDTH: usize = 12;
+
+/// Format a byte count with base-1000 units. `align` pads the unit-less case so
+/// that the unit suffixes line up in a right-aligned column.
+pub fn size_str(size: Option<usize>, align: bool) -> String {
+    if size.is_none() {
+        return "".to_string();
+    }
+    let size = size.unwrap();
+    let units = [" B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+    let base: usize = 1000;
+    let i = if size > 0 {
+        size.ilog10() / base.ilog10()
+    } else {
+        0
+    };
+    let size = size as f64 / base.pow(i) as f64;
+    if i == 0 {
+        format!(
+            "{:.0}{}{}",
+            size,
+            if align { "  " } else { "" },
+            units[i as usize]
+        )
+    } else {
+        format!("{:.1} {}", size, units[i as usize])
+    }
+}
+
+/// Format a file count with base-1000 units.
+pub fn rentries_str(rentries: Option<usize>, align: bool) -> String {
+    if rentries.is_none() {
+        return "".to_string();
+    }
+    let rentries = rentries.unwrap();
+    let units = ["", "K", "M", "G", "T", "P", "E", "Z", "Y"];
+    let base: usize = 1000;
+    let i = if rentries > 0 {
+        rentries.ilog10() / base.ilog10()
+    } else {
+        0
+    };
+    let rentries = rentries as f64 / base.pow(i) as f64;
+    if i == 0 {
+        format!("{:.0}{}", rentries, if align { "    " } else { "" })
+    } else {
+        format!("{:.1} {}", rentries, units[i as usize])
+    }
+}
+
+/// Format a Unix timestamp like 'ls -l' does: times within `current_year` show
+/// the clock time, older ones show the year instead.
+pub fn ctime_str(ctime_seconds: usize, current_year: isize) -> String {
+    let Ok(secs) = i64::try_from(ctime_seconds) else {
+        return String::new();
+    };
+    let Some(ctime) = DateTime::from_timestamp_secs(secs) else {
+        return String::new();
+    };
+    let ctime: DateTime<Local> = ctime.into();
+    let fmt = if (ctime.year() as isize) == current_year {
+        "%b %e %H:%M"
+    } else {
+        "%b %e  %Y"
+    };
+    ctime.format(fmt).to_string()
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -4,6 +4,47 @@ use chrono::{DateTime, Datelike, Local};
 /// 'Jan  1  2000' or 'Dec 31 12:34'
 pub const CTIME_FMT_WIDTH: usize = 12;
 
+/// How sizes and counts are rendered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Numbers {
+    /// Scaled to a base-1000 unit, as in "1.5 MB".
+    Units,
+    /// In full, as in "1500000": wider, but exact.
+    Exact,
+}
+
+impl Numbers {
+    /// Picks the form from the toggle both output modes present.
+    pub fn from_exact(exact: bool) -> Numbers {
+        if exact {
+            Numbers::Exact
+        } else {
+            Numbers::Units
+        }
+    }
+
+    /// `align` pads the unit form so that suffixes line up in a right-aligned
+    /// column; it has nothing to pad in the exact form.
+    pub fn size(self, size: Option<usize>, align: bool) -> String {
+        match self {
+            Numbers::Units => size_str(size, align),
+            Numbers::Exact => exact(size),
+        }
+    }
+
+    pub fn count(self, count: Option<usize>, align: bool) -> String {
+        match self {
+            Numbers::Units => rentries_str(count, align),
+            Numbers::Exact => exact(count),
+        }
+    }
+}
+
+/// Missing values render empty, as they do in the unit forms.
+fn exact(value: Option<usize>) -> String {
+    value.map(|v| v.to_string()).unwrap_or_default()
+}
+
 /// Advance to the next unit when rounding to one decimal would carry, so that
 /// 999_999 shows as "1.0 MB" rather than "1000.0 KB", which is a character wider
 /// than the columns allow.
@@ -18,7 +59,7 @@ fn carry_unit(value: usize, unit_index: u32, num_units: usize) -> u32 {
 
 /// Format a byte count with base-1000 units. `align` pads the unit-less case so
 /// that the unit suffixes line up in a right-aligned column.
-pub fn size_str(size: Option<usize>, align: bool) -> String {
+fn size_str(size: Option<usize>, align: bool) -> String {
     if size.is_none() {
         return "".to_string();
     }
@@ -45,7 +86,7 @@ pub fn size_str(size: Option<usize>, align: bool) -> String {
 }
 
 /// Format a file count with base-1000 units.
-pub fn rentries_str(rentries: Option<usize>, align: bool) -> String {
+fn rentries_str(rentries: Option<usize>, align: bool) -> String {
     if rentries.is_none() {
         return "".to_string();
     }
@@ -177,6 +218,39 @@ mod tests {
         let secs = 992_606_400; // 2001-06-15T12:00:00Z
         assert!(ctime_str(secs, 2026).contains("2001"));
         assert!(!ctime_str(secs, 2001).contains("2001"));
+    }
+
+    #[test]
+    fn exact_renders_values_in_full() {
+        assert_eq!(Numbers::Exact.size(Some(1_500_000), true), "1500000");
+        assert_eq!(Numbers::Exact.size(Some(0), true), "0");
+        assert_eq!(
+            Numbers::Exact.size(Some(usize::MAX), false),
+            usize::MAX.to_string()
+        );
+        assert_eq!(Numbers::Exact.count(Some(48_213), true), "48213");
+
+        // Alignment padding is a unit-form concern, so it must not appear here.
+        assert_eq!(
+            Numbers::Exact.size(Some(120), true),
+            Numbers::Exact.size(Some(120), false)
+        );
+    }
+
+    /// Both forms have to agree on how a missing value looks, since the callers
+    /// substitute their own placeholder for it.
+    #[test]
+    fn missing_values_render_empty_in_both_forms() {
+        for numbers in [Numbers::Units, Numbers::Exact] {
+            assert_eq!(numbers.size(None, true), "");
+            assert_eq!(numbers.count(None, true), "");
+        }
+    }
+
+    #[test]
+    fn units_go_through_numbers_unchanged() {
+        assert_eq!(Numbers::Units.size(Some(1_500_000), false), "1.5 MB");
+        assert_eq!(Numbers::Units.count(Some(48_213), false), "48.2 K");
     }
 
     /// A garbage rctime xattr must not panic.

--- a/src/format.rs
+++ b/src/format.rs
@@ -4,6 +4,18 @@ use chrono::{DateTime, Datelike, Local};
 /// 'Jan  1  2000' or 'Dec 31 12:34'
 pub const CTIME_FMT_WIDTH: usize = 12;
 
+/// Advance to the next unit when rounding to one decimal would carry, so that
+/// 999_999 shows as "1.0 MB" rather than "1000.0 KB", which is a character wider
+/// than the columns allow.
+fn carry_unit(value: usize, unit_index: u32, num_units: usize) -> u32 {
+    let scaled = value as f64 / 1000f64.powi(unit_index as i32);
+    if scaled >= 999.95 && (unit_index as usize) + 1 < num_units {
+        unit_index + 1
+    } else {
+        unit_index
+    }
+}
+
 /// Format a byte count with base-1000 units. `align` pads the unit-less case so
 /// that the unit suffixes line up in a right-aligned column.
 pub fn size_str(size: Option<usize>, align: bool) -> String {
@@ -18,6 +30,7 @@ pub fn size_str(size: Option<usize>, align: bool) -> String {
     } else {
         0
     };
+    let i = carry_unit(size, i, units.len());
     let size = size as f64 / base.pow(i) as f64;
     if i == 0 {
         format!(
@@ -44,6 +57,7 @@ pub fn rentries_str(rentries: Option<usize>, align: bool) -> String {
     } else {
         0
     };
+    let i = carry_unit(rentries, i, units.len());
     let rentries = rentries as f64 / base.pow(i) as f64;
     if i == 0 {
         format!("{:.0}{}", rentries, if align { "    " } else { "" })
@@ -68,4 +82,106 @@ pub fn ctime_str(ctime_seconds: usize, current_year: isize) -> String {
         "%b %e  %Y"
     };
     ctime.format(fmt).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn size_units() {
+        assert_eq!(size_str(None, false), "");
+        assert_eq!(size_str(Some(0), false), "0 B");
+        assert_eq!(size_str(Some(1), false), "1 B");
+        assert_eq!(size_str(Some(999), false), "999 B");
+        assert_eq!(size_str(Some(1000), false), "1.0 KB");
+        assert_eq!(size_str(Some(1500), false), "1.5 KB");
+        assert_eq!(size_str(Some(1_000_000), false), "1.0 MB");
+        assert_eq!(size_str(Some(1_500_000_000), false), "1.5 GB");
+        assert_eq!(size_str(Some(1_000_000_000_000), false), "1.0 TB");
+        assert_eq!(size_str(Some(1_000_000_000_000_000), false), "1.0 PB");
+    }
+
+    /// `align` may only pad: it must not change the value or the unit.
+    #[test]
+    fn size_align_only_pads() {
+        for size in [0usize, 1, 999, 1000, 1_500_000, usize::MAX] {
+            let tokens = |align| -> Vec<String> {
+                size_str(Some(size), align)
+                    .split_whitespace()
+                    .map(str::to_string)
+                    .collect()
+            };
+            assert_eq!(tokens(true), tokens(false), "size {} changed", size);
+        }
+    }
+
+    /// The list layout right-aligns sizes in an 8-wide field; overflowing it would
+    /// shift every column after it.
+    #[test]
+    fn size_fits_its_column() {
+        for size in [0usize, 1, 999, 1000, 999_999, usize::MAX] {
+            let s = size_str(Some(size), true);
+            assert!(s.len() <= 8, "{:?} is wider than its column", s);
+        }
+    }
+
+    #[test]
+    fn rentries_units() {
+        assert_eq!(rentries_str(None, false), "");
+        assert_eq!(rentries_str(Some(0), false), "0");
+        assert_eq!(rentries_str(Some(999), false), "999");
+        assert_eq!(rentries_str(Some(1000), false), "1.0 K");
+        assert_eq!(rentries_str(Some(48_213), false), "48.2 K");
+        assert_eq!(rentries_str(Some(1_000_000), false), "1.0 M");
+    }
+
+    #[test]
+    fn rentries_align_only_pads() {
+        for rentries in [0usize, 1, 999, 1000, 48_213, usize::MAX] {
+            let tokens = |align| -> Vec<String> {
+                rentries_str(Some(rentries), align)
+                    .split_whitespace()
+                    .map(str::to_string)
+                    .collect()
+            };
+            assert_eq!(tokens(true), tokens(false), "count {} changed", rentries);
+        }
+    }
+
+    /// The list layout right-aligns counts in a 7-wide field.
+    #[test]
+    fn rentries_fits_its_column() {
+        for rentries in [0usize, 1, 999, 1000, 999_999, usize::MAX] {
+            let s = rentries_str(Some(rentries), true);
+            assert!(s.len() <= 7, "{:?} is wider than its column", s);
+        }
+    }
+
+    /// Both branches of the format must produce the width the column layout assumes.
+    /// Timestamps here are mid-year and mid-day so no timezone can shift the year
+    /// or the day-of-month digit count.
+    #[test]
+    fn ctime_width_is_constant() {
+        // 2001-06-05T12:00:00Z (one-digit day) and 2001-06-15T12:00:00Z
+        for secs in [991_742_400usize, 992_606_400] {
+            for current_year in [2001isize, 2026] {
+                let s = ctime_str(secs, current_year);
+                assert_eq!(s.len(), CTIME_FMT_WIDTH, "{:?} has wrong width", s);
+            }
+        }
+    }
+
+    #[test]
+    fn ctime_shows_year_only_for_other_years() {
+        let secs = 992_606_400; // 2001-06-15T12:00:00Z
+        assert!(ctime_str(secs, 2026).contains("2001"));
+        assert!(!ctime_str(secs, 2001).contains("2001"));
+    }
+
+    /// A garbage rctime xattr must not panic.
+    #[test]
+    fn ctime_out_of_range_is_empty() {
+        assert_eq!(ctime_str(usize::MAX, 2026), "");
+    }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -9,11 +9,13 @@ const ATTR_BUF_SIZE: usize = 64;
 const DIR_RBYTES_ATTR: &str = "ceph.dir.rbytes";
 const DIR_RCTIME_ATTR: &str = "ceph.dir.rctime";
 const DIR_RENTRIES_ATTR: &str = "ceph.dir.rentries";
+const DIR_ENTRIES_ATTR: &str = "ceph.dir.entries";
 
 lazy_static! {
     static ref DIR_RBYTES_ATTR_C: CString = CString::new(DIR_RBYTES_ATTR).unwrap();
     static ref DIR_RCTIME_ATTR_C: CString = CString::new(DIR_RCTIME_ATTR).unwrap();
     static ref DIR_RENTRIES_ATTR_C: CString = CString::new(DIR_RENTRIES_ATTR).unwrap();
+    static ref DIR_ENTRIES_ATTR_C: CString = CString::new(DIR_ENTRIES_ATTR).unwrap();
 }
 
 lazy_static! {
@@ -124,6 +126,13 @@ fn get_xattr(path: &Path, attr: &CString) -> Option<String> {
         return None;
     }
     Some(String::from_utf8_lossy(&buf[..(bytes_read as usize)]).to_string())
+}
+
+/// The non-recursive entry count -- how many dents a readdir of `path` will
+/// return. Unlike `rentries` there is no self-count to subtract.
+pub fn get_entries(path: &Path) -> Option<usize> {
+    let entries = get_xattr(path, &DIR_ENTRIES_ATTR_C)?;
+    entries.trim().parse::<usize>().ok()
 }
 
 pub fn get_rentries(path: &Path) -> Option<usize> {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -144,5 +144,8 @@ pub fn get_rctime(path: &Path) -> Option<usize> {
     let rctime = get_xattr(path, &DIR_RCTIME_ATTR_C)?;
     // convert rctime xattr from string ("seconds.nanos") to unsigned
     let rctime = rctime.trim().split(".").next()?.parse::<usize>().ok()?;
+    // Zero is passed through: creating a directory sets its ctime but not its rctime,
+    // so one that nothing has happened in since reports zero, and the epoch is the
+    // idiomatic way for a Unix timestamp to say it was never set.
     Some(rctime)
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -9,12 +9,16 @@ const ATTR_BUF_SIZE: usize = 64;
 const DIR_RBYTES_ATTR: &str = "ceph.dir.rbytes";
 const DIR_RCTIME_ATTR: &str = "ceph.dir.rctime";
 const DIR_RENTRIES_ATTR: &str = "ceph.dir.rentries";
+const DIR_RFILES_ATTR: &str = "ceph.dir.rfiles";
+const DIR_RSUBDIRS_ATTR: &str = "ceph.dir.rsubdirs";
 const DIR_ENTRIES_ATTR: &str = "ceph.dir.entries";
 
 lazy_static! {
     static ref DIR_RBYTES_ATTR_C: CString = CString::new(DIR_RBYTES_ATTR).unwrap();
     static ref DIR_RCTIME_ATTR_C: CString = CString::new(DIR_RCTIME_ATTR).unwrap();
     static ref DIR_RENTRIES_ATTR_C: CString = CString::new(DIR_RENTRIES_ATTR).unwrap();
+    static ref DIR_RFILES_ATTR_C: CString = CString::new(DIR_RFILES_ATTR).unwrap();
+    static ref DIR_RSUBDIRS_ATTR_C: CString = CString::new(DIR_RSUBDIRS_ATTR).unwrap();
     static ref DIR_ENTRIES_ATTR_C: CString = CString::new(DIR_ENTRIES_ATTR).unwrap();
 }
 
@@ -147,6 +151,19 @@ pub fn get_rbytes(path: &Path) -> Option<usize> {
     // convert rbytes xattr from string to unsigned
     let rbytes = rbytes.trim().parse::<usize>().ok()?;
     Some(rbytes)
+}
+
+/// The recursive file count. Unlike `rentries` there is no self to subtract:
+/// only `rsubdirs` counts the directory itself.
+pub fn get_rfiles(path: &Path) -> Option<usize> {
+    let rfiles = get_xattr(path, &DIR_RFILES_ATTR_C)?;
+    rfiles.trim().parse::<usize>().ok()
+}
+
+/// The recursive directory count, including the directory itself.
+pub fn get_rsubdirs(path: &Path) -> Option<usize> {
+    let rsubdirs = get_xattr(path, &DIR_RSUBDIRS_ATTR_C)?;
+    rsubdirs.trim().parse::<usize>().ok()
 }
 
 pub fn get_rctime(path: &Path) -> Option<usize> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,9 @@ directories ahead of files whatever the field and direction.
 -e prints sizes and counts in full rather than scaled to a unit. The parseable
 format is always exact, so -e has no effect there.
 
+The interface names as few colors as it can, inheriting the terminal's own, so it
+suits a light terminal as well as a dark one. Flat listings are never colored.
+
 Note the following differences from 'ls -l':
   * The time shown is recursive for directories
   * The time shown is the time at which a file's contents *or* its metadata

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,9 @@ mirror the interface's sort keys, and apply to both output modes. -r reverses
 whichever order is in effect, so 'cephdu -r' reads smallest first, and -d groups
 directories ahead of files whatever the field and direction.
 
+-e prints sizes and counts in full rather than scaled to a unit. The parseable
+format is always exact, so -e has no effect there.
+
 Note the following differences from 'ls -l':
   * The time shown is recursive for directories
   * The time shown is the time at which a file's contents *or* its metadata
@@ -74,6 +77,10 @@ struct Cli {
     /// List directories before files
     #[arg(short, long)]
     dirs_first: bool,
+
+    /// Show sizes and counts in full instead of scaled to a unit
+    #[arg(short, long)]
+    exact: bool,
 }
 
 /// The startup sort order, mirroring the interface's sort keys. Each field starts
@@ -141,7 +148,7 @@ fn main() -> Result<()> {
     let format = if args.parseable {
         Some(Format::Parseable)
     } else if args.flat {
-        Some(Format::Human)
+        Some(Format::Human { exact: args.exact })
     } else if !args.tui && !std::io::stdout().is_terminal() {
         Some(Format::Parseable)
     } else {
@@ -166,6 +173,8 @@ fn main() -> Result<()> {
         }
         app
     });
+
+    app.exact = args.exact;
 
     color_eyre::install()?;
     let mut terminal = ratatui::init();

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,10 @@ struct Cli {
     #[arg(short, long)]
     long: bool,
 
+    /// Open the interactive interface with the info panel shown
+    #[arg(short, long, conflicts_with_all = ["flat", "parseable", "long"])]
+    info: bool,
+
     // Metadata reads in flight at once. Deliberately hidden and absent from the
     // README: it changes speed, never output, and the flag may change or vanish.
     // Keep it out of any user-facing text.
@@ -200,7 +204,7 @@ fn main() -> Result<()> {
         &path,
         path_was_explicit,
         options,
-        args.exact,
+        &args,
     ));
 
     // cleanup terminal
@@ -248,10 +252,14 @@ async fn run_app<B: Backend>(
     path: &Path,
     path_was_explicit: bool,
     options: Options,
-    exact: bool,
+    args: &Cli,
 ) -> Result<()> {
     let (mut app, mut listings) = App::new(options);
-    app.exact = exact;
+    app.exact = args.exact;
+    if args.info {
+        // Zeros until the first listing lands, which recomputes it.
+        app.toggle_info();
+    }
     // Purely for the frame drawn before the first listing lands, which replaces it
     // with the canonical path.
     app.cwd = path.to_path_buf();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,36 @@
 use app::Message;
+use chrono::{Datelike, Local};
 use clap::Parser;
 use color_eyre::Result;
 use crossterm::event::{self, Event};
 use ratatui::Terminal;
 use ratatui::backend::Backend;
-use std::path::PathBuf;
+use std::io::{IsTerminal, Write};
+use std::path::{Path, PathBuf};
 
 mod app;
+mod flat;
 mod format;
 mod fs;
 mod navigation;
 mod popup;
 mod ui;
 
-use crate::{app::App, ui::ui};
+use crate::{app::App, flat::Format, ui::ui};
 
 const DEFAULT_DIR: Option<&str> = option_env!("CEPHDU_DEFAULT_DIR");
 
 /// Display ceph space and file count (inode) usage in an interactive terminal
 #[derive(Parser)]
 #[clap(after_help = r#"
+The interactive interface is used when stdout is a terminal. Otherwise a flat
+listing is printed, as if --parseable had been given.
+
+Flat listings have one row per entry: size, file count, modified time, user,
+group, name, with '-' for values the filesystem does not provide. --flat writes
+them with units for reading; --parseable writes raw tab-separated values in a
+format that does not vary with the terminal.
+
 Note the following differences from 'ls -l':
   * The time shown is recursive for directories
   * The time shown is the time at which a file's contents *or* its metadata
@@ -31,6 +42,18 @@ Note the following differences from 'ls -l':
 struct Cli {
     /// Path to the directory to display
     path: Option<std::path::PathBuf>,
+
+    /// Print a flat text listing, with units, instead of the interactive interface
+    #[arg(short, long)]
+    flat: bool,
+
+    /// Print a flat text listing of raw values, for parsing
+    #[arg(short, long)]
+    parseable: bool,
+
+    /// Use the interactive interface even if stdout is not a terminal
+    #[arg(long, conflicts_with_all = ["flat", "parseable"])]
+    tui: bool,
 }
 
 fn main() -> Result<()> {
@@ -38,7 +61,24 @@ fn main() -> Result<()> {
 
     let path_was_explicit = args.path.is_some();
 
-    let path: PathBuf = args.path.unwrap_or_else(default_dir);
+    let path: PathBuf = args.path.clone().unwrap_or_else(default_dir);
+
+    // The interactive interface draws to stdout, so it can only work on a terminal.
+    // Whatever is reading a pipe or a file is more often a program than a person,
+    // hence the parseable format there. --tui is honored anyway, for pty-wrapping
+    // tools that defeat the detection.
+    let format = if args.parseable {
+        Some(Format::Parseable)
+    } else if args.flat {
+        Some(Format::Human)
+    } else if !args.tui && !std::io::stdout().is_terminal() {
+        Some(Format::Parseable)
+    } else {
+        None
+    };
+    if let Some(format) = format {
+        return run_flat(&path, &format);
+    }
 
     let mut app = App::new(Some(&path)).unwrap_or_else(|e| {
         let mut app = App::new(Some(&PathBuf::from("."))).unwrap_or_else(|_| {
@@ -64,6 +104,36 @@ fn main() -> Result<()> {
     ratatui::restore();
 
     Ok(())
+}
+
+/// Print a flat listing of `path`. Unlike the interactive interface, this doesn't
+/// fall back to the current directory on failure: a script needs to see the error
+/// rather than a listing of somewhere else.
+fn run_flat(path: &Path, format: &Format) -> Result<()> {
+    let listing = app::DirListing::from(path, app::DEFAULT_SORT_MODE).unwrap_or_else(|e| {
+        eprintln!("Error opening {:?}: {}", path, e);
+        std::process::exit(1);
+    });
+
+    if !listing.is_ceph() {
+        eprintln!(
+            "Warning: {:?} is not a Ceph directory; directory sizes and counts are unavailable",
+            path
+        );
+    }
+
+    let current_year = Local::now().year() as isize;
+
+    let stdout = std::io::stdout();
+    let mut out = std::io::BufWriter::new(stdout.lock());
+    let res =
+        flat::write_listing(&listing, format, current_year, &mut out).and_then(|()| out.flush());
+
+    match res {
+        // Closing the pipe early, as in 'cephdu --flat | head', is not a failure.
+        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        other => Ok(other?),
+    }
 }
 
 fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,13 @@
-use app::Message;
 use chrono::{Datelike, Local};
 use clap::Parser;
 use color_eyre::Result;
-use crossterm::event::{self, Event};
+use crossterm::event::{Event, EventStream, KeyEventKind};
 use ratatui::Terminal;
 use ratatui::backend::Backend;
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tokio_stream::StreamExt;
 
 mod app;
 mod flat;
@@ -17,7 +18,7 @@ mod popup;
 mod ui;
 
 use crate::{
-    app::{App, Options, SortField, SortMode},
+    app::{App, OnError, Options, SortField, SortMode},
     flat::Format,
     ui::ui,
 };
@@ -178,32 +179,27 @@ fn main() -> Result<()> {
         return run_flat(&path, &format, options);
     }
 
-    let mut app = App::new(Some(&path), options).unwrap_or_else(|e| {
-        let mut app = App::new(Some(&PathBuf::from(".")), options).unwrap_or_else(|_| {
-            eprintln!("Error opening {:?}: {}", path, e);
-            std::process::exit(1);
-        });
-
-        if path_was_explicit {
-            app.message(Some(Message {
-                text: format!("Error opening {:?}: {}", path, e),
-                kind: app::MessageKind::Warning,
-            }));
-        }
-        app
-    });
-
-    app.exact = args.exact;
-
     color_eyre::install()?;
+    // The runtime multiplexes wake-ups -- key presses, listing results, the
+    // progress tick -- while the filesystem work itself runs on plain threads that
+    // App manages, so a single-threaded runtime is all the loop needs.
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()?;
     let mut terminal = ratatui::init();
 
-    run_app(&mut terminal, &mut app)?;
+    let res = runtime.block_on(run_app(
+        &mut terminal,
+        &path,
+        path_was_explicit,
+        options,
+        args.exact,
+    ));
 
     // cleanup terminal
     ratatui::restore();
 
-    Ok(())
+    res
 }
 
 /// Print a flat listing of `path`. Unlike the interactive interface, this doesn't
@@ -236,15 +232,54 @@ fn run_flat(path: &Path, format: &Format, options: Options) -> Result<()> {
     }
 }
 
-fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<()> {
-    while !app.should_exit {
-        terminal.draw(|f| ui(f, app))?;
+/// While a read is in flight, wake up this often anyway so the progress notice
+/// stays current; there is no free-running tick otherwise.
+const PROGRESS_TICK: Duration = Duration::from_millis(100);
 
-        if let Event::Key(key) = event::read()? {
-            if key.kind == event::KeyEventKind::Release {
-                continue;
-            }
-            app.handle_key(key);
+async fn run_app<B: Backend>(
+    terminal: &mut Terminal<B>,
+    path: &Path,
+    path_was_explicit: bool,
+    options: Options,
+    exact: bool,
+) -> Result<()> {
+    let (mut app, mut listings) = App::new(options);
+    app.exact = exact;
+    // Purely for the frame drawn before the first listing lands, which replaces it
+    // with the canonical path.
+    app.cwd = path.to_path_buf();
+
+    // The fallback App::new used to apply, now expressed as what to do when the
+    // first listing fails: warn only when the user named the path themselves, and
+    // don't fall back to where we already are.
+    let on_error = if path == Path::new(".") {
+        OnError::Message
+    } else {
+        OnError::Fallback {
+            path: PathBuf::from("."),
+            warn: path_was_explicit,
+        }
+    };
+    app.start_listing(path.to_path_buf(), on_error, false);
+
+    let mut events = EventStream::new();
+    while !app.should_exit {
+        terminal.draw(|f| ui(f, &mut app))?;
+
+        tokio::select! {
+            event = events.next() => match event {
+                Some(Ok(Event::Key(key))) => {
+                    if key.kind != KeyEventKind::Release {
+                        app.handle_key(key);
+                    }
+                }
+                // Resize and the like: fall through to redraw.
+                Some(Ok(_)) => {}
+                Some(Err(e)) => return Err(e.into()),
+                None => break,
+            },
+            Some(msg) = listings.recv() => app.on_listing_msg(msg),
+            _ = tokio::time::sleep(PROGRESS_TICK), if app.is_reading() => {}
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ mod popup;
 mod ui;
 
 use crate::{
-    app::{App, SortField, SortMode},
+    app::{App, Options, SortField, SortMode},
     flat::Format,
     ui::ui,
 };
@@ -27,32 +27,37 @@ const DEFAULT_DIR: Option<&str> = option_env!("CEPHDU_DEFAULT_DIR");
 /// Display ceph space and file count (inode) usage in an interactive terminal
 #[derive(Parser)]
 #[clap(after_help = r#"
-The interactive interface is used when stdout is a terminal. Otherwise a flat
-listing is printed, as if --parseable had been given.
+The interactive interface (terminal user interface, or TUI) is used when stdout is a
+terminal. Otherwise, --parseable is enabled by default, so that the output can be processed
+through pipes and redirects.
 
-Flat listings have one row per entry: size, file count, modified time, user,
-group, name, with '-' for values the filesystem does not provide. --flat writes
-them with units for reading; --parseable writes raw tab-separated values in a
-format that does not vary with the terminal.
+Parseable listings have one row per entry: size, file count, change time, user,
+group, name. In flat mode, columns the filesystem does not provide or were not requested
+are skipped. In parseable mode, they are rendered as -. --flat writes with units for reading;
+--parseable writes raw tab-separated values.
 
-Listings are sorted largest first unless one of the sort flags is given. Those
-mirror the interface's sort keys, and apply to both output modes. -r reverses
-whichever order is in effect, so 'cephdu -r' reads smallest first, and -d groups
-directories ahead of files whatever the field and direction.
+Listings are sorted by bytes unless one of the sort flags is given. Those mirror the TUI's
+sort keys and apply to both TUI and flat. -r reverses whichever order is in effect, so
+'cephdu -r' reads smallest first. -d groups all directories before files.
 
 -e prints sizes and counts in full rather than scaled to a unit. The parseable
 format is always exact, so -e has no effect there.
 
-The interface names as few colors as it can, inheriting the terminal's own, so it
-suits a light terminal as well as a dark one. Flat listings are never colored.
+-l (implies flat) reads the two things that cost extra syscalls: the owner and a
+directory's recursive time. Without it a directory needs no stat at all -- its size
+and count are xattrs and its kind comes from readdir -- and makes one fewer xattr
+call. A file's time comes from the stat it needs anyway for its size, so it is always
+shown, and the parseable format marks what was not read '-' so that its fields never
+move.
 
 Note the following differences from 'ls -l':
-  * The time shown is recursive for directories
   * The time shown is the time at which a file's contents *or* its metadata
-    have been modified (ctime). This is subtly different from 'ls -l', where
-    the timestamp only changes if the contents are modified (mtime)
+    have been changed (ctime). 'ls -l' shows the time at which the contents were
+    modified (mtime).
+  * The time shown for a directory is the recursive ctime (rctime), including the
+    directory itself. New directories do not have an rctime.
   * The size shown is recursive for directories (may also be true for
-    'ls -l' depending on ceph deployment)
+    'ls -l' depending on ceph deployment).
 "#)]
 struct Cli {
     /// Path to the directory to display
@@ -62,12 +67,12 @@ struct Cli {
     #[arg(short, long)]
     flat: bool,
 
-    /// Print a flat text listing of raw values, for parsing
+    /// Print a flat text listing of raw values for parsing
     #[arg(short, long)]
     parseable: bool,
 
     /// Use the interactive interface even if stdout is not a terminal
-    #[arg(long, conflicts_with_all = ["flat", "parseable"])]
+    #[arg(long, conflicts_with_all = ["flat", "parseable", "long"])]
     tui: bool,
 
     #[command(flatten)]
@@ -84,6 +89,10 @@ struct Cli {
     /// Show sizes and counts in full instead of scaled to a unit
     #[arg(short, long)]
     exact: bool,
+
+    /// Show the owner and directory times, which cost extra syscalls. Implies -f.
+    #[arg(short, long)]
+    long: bool,
 }
 
 /// The startup sort order, mirroring the interface's sort keys. Each field starts
@@ -108,7 +117,7 @@ struct SortFlags {
     #[arg(short = 'u', long)]
     owner: bool,
 
-    /// Sort by modification time
+    /// Sort by change time
     #[arg(short, long)]
     time: bool,
 }
@@ -143,30 +152,37 @@ fn main() -> Result<()> {
     } else {
         args.sort.mode()
     };
-
     // The interactive interface draws to stdout, so it can only work on a terminal.
     // Whatever is reading a pipe or a file is more often a program than a person,
     // hence the parseable format there. --tui is honored anyway, for pty-wrapping
     // tools that defeat the detection.
     let format = if args.parseable {
         Some(Format::Parseable)
-    } else if args.flat {
+    } else if args.flat || args.long {
         Some(Format::Human { exact: args.exact })
     } else if !args.tui && !std::io::stdout().is_terminal() {
         Some(Format::Parseable)
     } else {
         None
     };
+
+    let options = Options {
+        sort_mode,
+        dirs_first: args.dirs_first,
+        // Ordering by one of these needs it read, whether or not it is shown.
+        owners: args.long || *sort_mode.field() == SortField::Owner,
+        times: args.long || *sort_mode.field() == SortField::CTime,
+    };
+
     if let Some(format) = format {
-        return run_flat(&path, &format, sort_mode, args.dirs_first);
+        return run_flat(&path, &format, options);
     }
 
-    let mut app = App::new(Some(&path), sort_mode, args.dirs_first).unwrap_or_else(|e| {
-        let mut app = App::new(Some(&PathBuf::from(".")), sort_mode, args.dirs_first)
-            .unwrap_or_else(|_| {
-                eprintln!("Error opening {:?}: {}", path, e);
-                std::process::exit(1);
-            });
+    let mut app = App::new(Some(&path), options).unwrap_or_else(|e| {
+        let mut app = App::new(Some(&PathBuf::from(".")), options).unwrap_or_else(|_| {
+            eprintln!("Error opening {:?}: {}", path, e);
+            std::process::exit(1);
+        });
 
         if path_was_explicit {
             app.message(Some(Message {
@@ -193,8 +209,8 @@ fn main() -> Result<()> {
 /// Print a flat listing of `path`. Unlike the interactive interface, this doesn't
 /// fall back to the current directory on failure: a script needs to see the error
 /// rather than a listing of somewhere else.
-fn run_flat(path: &Path, format: &Format, sort_mode: SortMode, dirs_first: bool) -> Result<()> {
-    let listing = app::DirListing::from(path, sort_mode, dirs_first).unwrap_or_else(|e| {
+fn run_flat(path: &Path, format: &Format, options: Options) -> Result<()> {
+    let listing = app::DirListing::from(path, options).unwrap_or_else(|e| {
         eprintln!("Error opening {:?}: {}", path, e);
         std::process::exit(1);
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use ratatui::backend::Backend;
 use std::path::PathBuf;
 
 mod app;
+mod format;
 mod fs;
 mod navigation;
 mod popup;

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,12 @@ struct Cli {
     /// Show the owner and directory times, which cost extra syscalls. Implies -f.
     #[arg(short, long)]
     long: bool,
+
+    // Metadata reads in flight at once. Deliberately hidden and absent from the
+    // README: it changes speed, never output, and the flag may change or vanish.
+    // Keep it out of any user-facing text.
+    #[arg(short = 'j', hide = true, default_value_t = 1)]
+    jobs: usize,
 }
 
 /// The startup sort order, mirroring the interface's sort keys. Each field starts
@@ -173,6 +179,7 @@ fn main() -> Result<()> {
         // Ordering by one of these needs it read, whether or not it is shown.
         owners: args.long || *sort_mode.field() == SortField::Owner,
         times: args.long || *sort_mode.field() == SortField::CTime,
+        jobs: args.jobs.max(1),
     };
 
     if let Some(format) = format {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,12 @@ The interactive interface (terminal user interface, or TUI) is used when stdout 
 terminal. Otherwise, --parseable is enabled by default, so that the output can be processed
 through pipes and redirects.
 
+Without a PATH, cephdu starts in the current directory if it is on Ceph. Otherwise it
+starts in $CEPHDU_DEFAULT_DIR if that is set, or in a default baked into the binary when
+it was built; a literal $USER in either is replaced with the current username. Setting
+the variable to the empty string disables the baked-in default too. With no default
+configured, the current directory is used regardless.
+
 Parseable listings have one row per entry: size, file count, change time, user,
 group, name. In flat mode, columns the filesystem does not provide or were not requested
 are skipped. In parseable mode, they are rendered as -. --flat writes with units for reading;
@@ -301,30 +307,34 @@ async fn run_app<B: Backend>(
 }
 
 /// Returns the cwd if it is a ceph dir.
-/// If not, returns DEFAULT_DIR if set.
-/// If not, the cwd is returned.
-/// Instances of $USER in DEFAULT_DIR are replaced with the current username.
+/// If not, returns the CEPHDU_DEFAULT_DIR environment variable, or DEFAULT_DIR
+/// if the variable is unset.
+/// If neither is set, the cwd is returned.
+/// Instances of $USER in either are replaced with the current username.
 fn default_dir() -> PathBuf {
     let cwd = PathBuf::from(".");
-    if DEFAULT_DIR.is_none() {
-        // short-circuit testing if cwd is ceph
+    // The variable wins over the baked-in value because it is set closer to the
+    // machine: a site's modulefile against whoever built the binary. Set-but-empty
+    // disables the baked-in value too, so a site can also switch the default off.
+    let configured = match std::env::var("CEPHDU_DEFAULT_DIR") {
+        Ok(dir) => (!dir.is_empty()).then_some(dir),
+        Err(_) => DEFAULT_DIR.map(str::to_string),
+    };
+    let Some(dir) = configured else {
+        // Nothing to fall back to, so skip the statfs.
         return cwd;
-    }
+    };
 
     if fs::get_fs(&cwd).map(fs::FSType::is_ceph).unwrap_or(false) {
         return cwd;
     }
 
-    DEFAULT_DIR
-        .and_then(|dir| {
-            if dir.contains("$USER") {
-                match std::env::var("USER") {
-                    Ok(username) => Some(PathBuf::from(dir.replace("$USER", &username))),
-                    Err(_) => None,
-                }
-            } else {
-                Some(PathBuf::from(dir))
-            }
-        })
-        .unwrap_or(PathBuf::from("."))
+    if dir.contains("$USER") {
+        match std::env::var("USER") {
+            Ok(username) => PathBuf::from(dir.replace("$USER", &username)),
+            Err(_) => cwd,
+        }
+    } else {
+        PathBuf::from(dir)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,8 @@ format that does not vary with the terminal.
 
 Listings are sorted largest first unless one of the sort flags is given. Those
 mirror the interface's sort keys, and apply to both output modes. -r reverses
-whichever order is in effect, so 'cephdu -r' reads smallest first.
+whichever order is in effect, so 'cephdu -r' reads smallest first, and -d groups
+directories ahead of files whatever the field and direction.
 
 Note the following differences from 'ls -l':
   * The time shown is recursive for directories
@@ -69,6 +70,10 @@ struct Cli {
     /// Reverse the sort order
     #[arg(short, long)]
     reverse: bool,
+
+    /// List directories before files
+    #[arg(short, long)]
+    dirs_first: bool,
 }
 
 /// The startup sort order, mirroring the interface's sort keys. Each field starts
@@ -143,14 +148,15 @@ fn main() -> Result<()> {
         None
     };
     if let Some(format) = format {
-        return run_flat(&path, &format, sort_mode);
+        return run_flat(&path, &format, sort_mode, args.dirs_first);
     }
 
-    let mut app = App::new(Some(&path), sort_mode).unwrap_or_else(|e| {
-        let mut app = App::new(Some(&PathBuf::from(".")), sort_mode).unwrap_or_else(|_| {
-            eprintln!("Error opening {:?}: {}", path, e);
-            std::process::exit(1);
-        });
+    let mut app = App::new(Some(&path), sort_mode, args.dirs_first).unwrap_or_else(|e| {
+        let mut app = App::new(Some(&PathBuf::from(".")), sort_mode, args.dirs_first)
+            .unwrap_or_else(|_| {
+                eprintln!("Error opening {:?}: {}", path, e);
+                std::process::exit(1);
+            });
 
         if path_was_explicit {
             app.message(Some(Message {
@@ -175,8 +181,8 @@ fn main() -> Result<()> {
 /// Print a flat listing of `path`. Unlike the interactive interface, this doesn't
 /// fall back to the current directory on failure: a script needs to see the error
 /// rather than a listing of somewhere else.
-fn run_flat(path: &Path, format: &Format, sort_mode: SortMode) -> Result<()> {
-    let listing = app::DirListing::from(path, sort_mode).unwrap_or_else(|e| {
+fn run_flat(path: &Path, format: &Format, sort_mode: SortMode, dirs_first: bool) -> Result<()> {
+    let listing = app::DirListing::from(path, sort_mode, dirs_first).unwrap_or_else(|e| {
         eprintln!("Error opening {:?}: {}", path, e);
         std::process::exit(1);
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,11 @@ mod navigation;
 mod popup;
 mod ui;
 
-use crate::{app::App, flat::Format, ui::ui};
+use crate::{
+    app::{App, SortField, SortMode},
+    flat::Format,
+    ui::ui,
+};
 
 const DEFAULT_DIR: Option<&str> = option_env!("CEPHDU_DEFAULT_DIR");
 
@@ -30,6 +34,10 @@ Flat listings have one row per entry: size, file count, modified time, user,
 group, name, with '-' for values the filesystem does not provide. --flat writes
 them with units for reading; --parseable writes raw tab-separated values in a
 format that does not vary with the terminal.
+
+Listings are sorted largest first unless one of the sort flags is given. Those
+mirror the interface's sort keys, and apply to both output modes. -r reverses
+whichever order is in effect, so 'cephdu -r' reads smallest first.
 
 Note the following differences from 'ls -l':
   * The time shown is recursive for directories
@@ -54,6 +62,59 @@ struct Cli {
     /// Use the interactive interface even if stdout is not a terminal
     #[arg(long, conflicts_with_all = ["flat", "parseable"])]
     tui: bool,
+
+    #[command(flatten)]
+    sort: SortFlags,
+
+    /// Reverse the sort order
+    #[arg(short, long)]
+    reverse: bool,
+}
+
+/// The startup sort order, mirroring the interface's sort keys. Each field starts
+/// in the direction `SortField::default_mode` gives it, so `-s` reads largest
+/// first, and the interface's usual keys still reverse it from there.
+#[derive(clap::Args)]
+#[group(multiple = false)]
+struct SortFlags {
+    /// Sort by name
+    #[arg(short, long)]
+    name: bool,
+
+    /// Sort by size
+    #[arg(short, long)]
+    size: bool,
+
+    /// Sort by file count
+    #[arg(short, long)]
+    count: bool,
+
+    /// Sort by owner
+    #[arg(short = 'u', long)]
+    owner: bool,
+
+    /// Sort by modification time
+    #[arg(short, long)]
+    time: bool,
+}
+
+impl SortFlags {
+    fn mode(&self) -> SortMode {
+        let field = if self.name {
+            SortField::Name
+        } else if self.size {
+            SortField::Size
+        } else if self.count {
+            SortField::Rentries
+        } else if self.owner {
+            SortField::Owner
+        } else if self.time {
+            SortField::CTime
+        } else {
+            return app::DEFAULT_SORT_MODE;
+        };
+        field.default_mode()
+    }
 }
 
 fn main() -> Result<()> {
@@ -62,6 +123,11 @@ fn main() -> Result<()> {
     let path_was_explicit = args.path.is_some();
 
     let path: PathBuf = args.path.clone().unwrap_or_else(default_dir);
+    let sort_mode = if args.reverse {
+        args.sort.mode().as_reversed()
+    } else {
+        args.sort.mode()
+    };
 
     // The interactive interface draws to stdout, so it can only work on a terminal.
     // Whatever is reading a pipe or a file is more often a program than a person,
@@ -77,11 +143,11 @@ fn main() -> Result<()> {
         None
     };
     if let Some(format) = format {
-        return run_flat(&path, &format);
+        return run_flat(&path, &format, sort_mode);
     }
 
-    let mut app = App::new(Some(&path)).unwrap_or_else(|e| {
-        let mut app = App::new(Some(&PathBuf::from("."))).unwrap_or_else(|_| {
+    let mut app = App::new(Some(&path), sort_mode).unwrap_or_else(|e| {
+        let mut app = App::new(Some(&PathBuf::from(".")), sort_mode).unwrap_or_else(|_| {
             eprintln!("Error opening {:?}: {}", path, e);
             std::process::exit(1);
         });
@@ -109,8 +175,8 @@ fn main() -> Result<()> {
 /// Print a flat listing of `path`. Unlike the interactive interface, this doesn't
 /// fall back to the current directory on failure: a script needs to see the error
 /// rather than a listing of somewhere else.
-fn run_flat(path: &Path, format: &Format) -> Result<()> {
-    let listing = app::DirListing::from(path, app::DEFAULT_SORT_MODE).unwrap_or_else(|e| {
+fn run_flat(path: &Path, format: &Format, sort_mode: SortMode) -> Result<()> {
+    let listing = app::DirListing::from(path, sort_mode).unwrap_or_else(|e| {
         eprintln!("Error opening {:?}: {}", path, e);
         std::process::exit(1);
     });

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -23,6 +23,7 @@ pub const HELP: &[[&str; 2]] = &[
     ["u", "Toggle show owner"],
     ["T", "Sort by modified time"],
     ["t", "Toggle show modified time"],
+    ["d", "Toggle listing directories first"],
     ["?, h", "Show this help message"],
     ["Home, g", "Select first entry"],
     ["End, G", "Select last entry"],
@@ -125,6 +126,9 @@ impl App {
             }
             KeyCode::Char('t') => {
                 self.show_ctime = !self.show_ctime;
+            }
+            KeyCode::Char('d') => {
+                self.dir_listing.toggle_dirs_first();
             }
             KeyCode::Char('r') | KeyCode::F(5) => {
                 self.cd(&self.cwd.clone());

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -27,6 +27,7 @@ pub const HELP: &[[&str; 2]] = &[
     ["T", "Sort by change time"],
     ["t", "Toggle show change time (reads it if needed)"],
     ["d", "Toggle listing directories first"],
+    ["i", "Toggle the info panel (this level vs recursive)"],
     ["e", "Toggle exact sizes and counts"],
     ["?, h", "Show this help message"],
     ["Home, g", "Select first entry"],
@@ -161,6 +162,9 @@ impl App {
             }
             KeyCode::Char('?') | KeyCode::Char('h') => {
                 self.help();
+            }
+            KeyCode::Char('i') => {
+                self.toggle_info();
             }
             _ => {}
         }

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use std::path::PathBuf;
 
@@ -11,7 +11,7 @@ static PAGE_BY: usize = 10;
 static SCROLL_BY: usize = 4;
 
 pub const HELP: &[[&str; 2]] = &[
-    ["q, Esc", "Quit"],
+    ["q", "Quit"],
     ["Down, j", "Move cursor down"],
     ["Up, k", "Move cursor up"],
     ["Page Down", "Jump cursor down"],
@@ -33,7 +33,7 @@ pub const HELP: &[[&str; 2]] = &[
     ["Home, g", "Select first entry"],
     ["End, G", "Select last entry"],
     ["r, F5", "Refresh"],
-    ["Ctrl-C", "Interrupt changing the directory"],
+    ["Esc, Ctrl-C", "Cancel reading a directory"],
     ["Space", "Go to original directory"],
 ];
 
@@ -119,8 +119,18 @@ impl App {
             KeyCode::Backspace => {
                 self.cd(&"..".into());
             }
-            KeyCode::Esc | KeyCode::Char('q') => {
+            KeyCode::Char('q') => {
                 self.should_exit = true;
+            }
+            // A cancel key must not double as a quit key: an extra press, or one
+            // landing just after the read finishes, would exit unintended. Hence
+            // Esc cancels and only q quits.
+            KeyCode::Esc => {
+                self.cancel_listing();
+            }
+            // Before the sort arm below, which must not swallow Ctrl-C as a 'c'.
+            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.cancel_listing();
             }
             KeyCode::Char('n') => self.sort_or_reverse(app::SortField::Name.default_mode()),
             KeyCode::Char('s') => self.sort_or_reverse(app::SortField::Size.default_mode()),
@@ -130,7 +140,10 @@ impl App {
             KeyCode::Char('U') => self.sort_or_reverse(app::SortField::Owner.default_mode()),
             KeyCode::Char('T') => self.sort_or_reverse(app::SortField::CTime.default_mode()),
             KeyCode::Char(' ') => {
-                self.cd(&self.original_cwd.clone());
+                // None only until the first listing lands; nowhere to go back to.
+                if let Some(original) = self.original_cwd.clone() {
+                    self.cd(&original);
+                }
             }
             KeyCode::Char('u') => {
                 self.toggle_owner();

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -110,19 +110,13 @@ impl App {
             KeyCode::Esc | KeyCode::Char('q') => {
                 self.should_exit = true;
             }
-            KeyCode::Char('n') => self.sort_or_reverse(app::SortMode::Normal(app::SortField::Name)),
-            KeyCode::Char('s') => {
-                self.sort_or_reverse(app::SortMode::Reversed(app::SortField::Size))
-            }
+            KeyCode::Char('n') => self.sort_or_reverse(app::SortField::Name.default_mode()),
+            KeyCode::Char('s') => self.sort_or_reverse(app::SortField::Size.default_mode()),
             KeyCode::Char('c') | KeyCode::Char('C') => {
-                self.sort_or_reverse(app::SortMode::Reversed(app::SortField::Rentries))
+                self.sort_or_reverse(app::SortField::Rentries.default_mode())
             }
-            KeyCode::Char('U') => {
-                self.sort_or_reverse(app::SortMode::Normal(app::SortField::Owner))
-            }
-            KeyCode::Char('T') => {
-                self.sort_or_reverse(app::SortMode::Reversed(app::SortField::CTime))
-            }
+            KeyCode::Char('U') => self.sort_or_reverse(app::SortField::Owner.default_mode()),
+            KeyCode::Char('T') => self.sort_or_reverse(app::SortField::CTime.default_mode()),
             KeyCode::Char(' ') => {
                 self.cd(&self.original_cwd.clone());
             }

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -7,12 +7,16 @@ use crate::app::App;
 use crate::ui::POPUP_TEXT_HEIGHT;
 
 static PAGE_BY: usize = 10;
+/// Columns per horizontal scroll step.
+static SCROLL_BY: usize = 4;
 
 pub const HELP: &[[&str; 2]] = &[
     ["q, Esc", "Quit"],
     ["Down, j", "Move cursor down"],
     ["Up, k", "Move cursor up"],
     ["Page Down", "Jump cursor down"],
+    ["Left", "Scroll left"],
+    ["Right", "Scroll right"],
     ["Page Up", "Jump cursor up"],
     ["Enter", "Open directory"],
     ["Backspace", "Go to parent directory"],
@@ -105,6 +109,12 @@ impl App {
             }
             KeyCode::PageDown => {
                 self.dir_listing.select_next(PAGE_BY);
+            }
+            KeyCode::Left => {
+                self.hscroll = self.hscroll.saturating_sub(SCROLL_BY);
+            }
+            KeyCode::Right => {
+                self.hscroll = self.hscroll.saturating_add(SCROLL_BY);
             }
             KeyCode::Backspace => {
                 self.cd(&"..".into());

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -24,9 +24,9 @@ pub const HELP: &[[&str; 2]] = &[
     ["s", "Sort by size"],
     ["c, C", "Sort by file count"],
     ["U", "Sort by owner"],
-    ["u", "Toggle show owner"],
-    ["T", "Sort by modified time"],
-    ["t", "Toggle show modified time"],
+    ["u", "Toggle show owner (reads it if needed)"],
+    ["T", "Sort by change time"],
+    ["t", "Toggle show change time (reads it if needed)"],
     ["d", "Toggle listing directories first"],
     ["e", "Toggle exact sizes and counts"],
     ["?, h", "Show this help message"],
@@ -133,10 +133,10 @@ impl App {
                 self.cd(&self.original_cwd.clone());
             }
             KeyCode::Char('u') => {
-                self.show_owner = !self.show_owner;
+                self.toggle_owner();
             }
             KeyCode::Char('t') => {
-                self.show_ctime = !self.show_ctime;
+                self.toggle_ctime();
             }
             KeyCode::Char('d') => {
                 self.dir_listing.toggle_dirs_first();

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -24,6 +24,7 @@ pub const HELP: &[[&str; 2]] = &[
     ["T", "Sort by modified time"],
     ["t", "Toggle show modified time"],
     ["d", "Toggle listing directories first"],
+    ["e", "Toggle exact sizes and counts"],
     ["?, h", "Show this help message"],
     ["Home, g", "Select first entry"],
     ["End, G", "Select last entry"],
@@ -129,6 +130,9 @@ impl App {
             }
             KeyCode::Char('d') => {
                 self.dir_listing.toggle_dirs_first();
+            }
+            KeyCode::Char('e') => {
+                self.exact = !self.exact;
             }
             KeyCode::Char('r') | KeyCode::F(5) => {
                 self.cd(&self.cwd.clone());

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 
 use crate::app;
 use crate::app::App;
-use crate::ui::POPUP_TEXT_HEIGHT;
 
 static PAGE_BY: usize = 10;
 /// Columns per horizontal scroll step.
@@ -75,7 +74,7 @@ impl App {
                 }
                 KeyCode::End | KeyCode::Char('G') => {
                     if let Some(popup) = &mut self.popup {
-                        popup.scroll_to(POPUP_TEXT_HEIGHT);
+                        popup.scroll_to_end();
                     }
                 }
                 _ => {}

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -1,7 +1,5 @@
 use ratatui::widgets::ScrollbarState;
 
-use crate::ui::POPUP_TEXT_HEIGHT;
-
 #[derive(Debug)]
 pub struct Popup {
     pub title: String,
@@ -10,6 +8,11 @@ pub struct Popup {
     pub text_width: usize,
     pub text_height: usize,
     scroll: usize,
+    /// Rows of text on screen, which only the renderer knows -- it depends on the
+    /// terminal. Zero until the first frame, and everything that depends on it is
+    /// re-clamped when it changes, so a key pressed before that frame can't leave
+    /// the scroll out of range.
+    view_height: usize,
     pub scrollbar_state: ScrollbarState,
 }
 
@@ -30,10 +33,19 @@ impl Popup {
             text_width,
             text_height,
             scroll: 0,
-            scrollbar_state: ScrollbarState::default()
-                .position(0)
-                .content_length(text_height.saturating_sub(POPUP_TEXT_HEIGHT)),
+            view_height: 0,
+            scrollbar_state: ScrollbarState::default().position(0),
         }
+    }
+
+    /// Tell the popup how many rows of text it is being drawn into.
+    pub fn set_view_height(&mut self, view_height: usize) {
+        if view_height == self.view_height {
+            return;
+        }
+        self.view_height = view_height;
+        // A taller terminal can leave the scroll past the new end.
+        self.scroll_to(self.scroll);
     }
     pub fn scroll(&self) -> usize {
         self.scroll
@@ -45,11 +57,21 @@ impl Popup {
 
     pub fn scroll_to(&mut self, line: usize) -> usize {
         self.scroll = line.min(self.max_scroll());
-        self.scrollbar_state = self.scrollbar_state.position(self.scroll);
+        self.scrollbar_state = self
+            .scrollbar_state
+            .position(self.scroll)
+            .content_length(self.max_scroll());
         self.scroll
     }
 
-    fn max_scroll(&self) -> usize {
-        self.text_height.saturating_sub(POPUP_TEXT_HEIGHT)
+    pub fn scroll_to_end(&mut self) -> usize {
+        self.scroll_to(usize::MAX)
+    }
+
+    /// The first line that can be shown at the top with text still filling the
+    /// view. Zero when the whole text fits, which is also when the scrollbar has
+    /// nothing to say.
+    pub fn max_scroll(&self) -> usize {
+        self.text_height.saturating_sub(self.view_height)
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -80,14 +80,22 @@ impl App {
         let cols = self.columns();
         let numbers = cols.numbers;
 
-        let title = Line::from(format!(
-            " {} ━━ {}, {} files ",
-            self.cwd.to_str().unwrap_or("[invalid UTF-8]"),
+        let stats = format!(
+            " {}, {} files ",
             numbers.size(Some(self.dir_listing.stats.total_size), false),
             numbers.count(Some(self.dir_listing.stats.total_rentries), false)
-        ))
-        .fg(TEXT_FG_COLOR)
-        .bold();
+        );
+
+        // Both titles and at least one border cell between them have to fit between
+        // the corners; whatever is left over is the path's, and the spaces framing it
+        // are part of that.
+        let budget = (area.width as usize)
+            .saturating_sub(2 + stats.chars().count() + 1)
+            .saturating_sub(2);
+        let path = truncate_start(self.cwd.to_str().unwrap_or("[invalid UTF-8]"), budget);
+
+        let title = Line::from(format!(" {} ", path)).fg(TEXT_FG_COLOR).bold();
+        let stats = Line::from(stats).fg(TEXT_FG_COLOR).bold();
 
         let helptitle = Line::from(" Press ? for help ").fg(TEXT_FG_COLOR).bold();
 
@@ -111,6 +119,7 @@ impl App {
 
         let block = Block::bordered()
             .title(title.left_aligned())
+            .title(stats.right_aligned())
             .title_bottom(Line::from(status).fg(TEXT_FG_COLOR).bold().left_aligned())
             .title_bottom(helptitle.right_aligned())
             .border_set(border::THICK);
@@ -264,6 +273,23 @@ fn render_popup(popup: &mut Popup, areas: [Rect; 2], buf: &mut Buffer) {
         buf,
         &mut popup.scrollbar_state,
     );
+}
+
+/// Keep the end of a path when it is too long to show: the deepest components are
+/// the ones that change while navigating, so the start is what gets dropped.
+fn truncate_start(path: &str, budget: usize) -> String {
+    const MARKER: char = '…';
+
+    let len = path.chars().count();
+    if len <= budget {
+        return path.to_string();
+    }
+    if budget == 0 {
+        return String::new();
+    }
+
+    let tail: String = path.chars().skip(len - (budget - 1)).collect();
+    format!("{}{}", MARKER, tail)
 }
 
 fn safe_div(a: usize, b: usize) -> f64 {
@@ -559,7 +585,7 @@ mod tests {
     /// Everything below the header, which carries the version number.
     const EXPECTED: &[&str] = &[
         "",
-        "┏ /ceph/users/alice ━━ 1.0 TB, 100.0 K files ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓",
+        "┏ /ceph/users/alice ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.0 TB, 100.0 K files ┓",
         "┃>          ┃                    ┃          ┃                    ┃ ..          ┃",
         "┃  800.0 GB ┃███████ 80.0%███████┃   60.0 K ┃███████ 60.0%███████┃ a/          ┃",
         "┃  200.0 GB ┃█████   20.0%       ┃   40.0 K ┃███████ 40.0%▍      ┃ b/          ┃",
@@ -861,6 +887,69 @@ mod tests {
         app.handle_key(KeyEvent::from(KeyCode::Right));
         assert_eq!(frame(&mut app), before, "scrolled a listing that fits");
         assert_eq!(app.hscroll, 0);
+    }
+
+    /// The path is what runs out of room, so it loses its start rather than pushing
+    /// the totals off the border.
+    #[test]
+    fn a_long_path_keeps_its_tail() {
+        let mut app = app();
+        app.cwd =
+            PathBuf::from("/ceph/users/alice/projects/simulations/run-0042/outputs/snapshots");
+
+        let border = frame(&mut app)[2].clone();
+
+        assert!(border.contains('…'), "{}", border);
+        assert!(border.contains("outputs/snapshots"), "{}", border);
+        assert!(
+            !border.contains("/ceph/users"),
+            "kept the start: {}",
+            border
+        );
+        assert!(border.ends_with("1.0 TB, 100.0 K files ┓"), "{}", border);
+        assert_eq!(border.chars().count(), 80, "{}", border);
+    }
+
+    /// Widening the totals takes room from the path, not from the border.
+    #[test]
+    fn the_totals_hold_the_right_edge() {
+        let mut app = app();
+        app.cwd =
+            PathBuf::from("/ceph/users/alice/projects/simulations/run-0042/outputs/snapshots");
+
+        for exact in [false, true] {
+            app.exact = exact;
+            let border = frame(&mut app)[2].clone();
+            assert!(border.ends_with("files ┓"), "exact={}: {}", exact, border);
+            assert_eq!(border.chars().count(), 80, "exact={}: {}", exact, border);
+        }
+    }
+
+    #[test]
+    fn truncate_start_keeps_the_tail() {
+        // Short enough to show whole, including exactly at the budget.
+        assert_eq!(truncate_start("/a/b", 10), "/a/b");
+        assert_eq!(truncate_start("/a/b", 4), "/a/b");
+
+        assert_eq!(truncate_start("/aaa/bbb/ccc", 8), "…bbb/ccc");
+        assert_eq!(truncate_start("/aaa/bbb/ccc", 1), "…");
+        assert_eq!(truncate_start("/aaa/bbb/ccc", 0), "");
+    }
+
+    /// The budget is in cells, so a multi-byte path must not overrun it.
+    #[test]
+    fn truncate_start_counts_characters() {
+        let path = "/données/été";
+        for budget in 1..=path.chars().count() {
+            let shown = truncate_start(path, budget);
+            assert_eq!(
+                shown.chars().count(),
+                budget,
+                "{:?} does not fill {} cells",
+                shown,
+                budget
+            );
+        }
     }
 
     /// The status area lives in the bottom border and must not disturb the rest of it.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2,10 +2,7 @@ use ratatui::{
     Frame,
     buffer::Buffer,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{
-        Color, Modifier, Style, Stylize,
-        palette::tailwind::{RED, SLATE, YELLOW},
-    },
+    style::{Color, Modifier, Style, Stylize},
     symbols::{self, border},
     text::{Line, Span, Text},
     widgets::{
@@ -18,33 +15,32 @@ use chrono::{Datelike, Local};
 
 use crate::app::App;
 use crate::app::DirEntry;
-use crate::app::EntryKind;
 use crate::app::ListingStats;
 use crate::app::Message;
 use crate::app::MessageKind;
 use crate::format::{CTIME_FMT_WIDTH, Numbers, ctime_str};
 use crate::popup::Popup;
 
-const SELECTED_BG_COLOR: Color = SLATE.c700;
-const SELECTED_STYLE: Style = Style::new()
-    .bg(SELECTED_BG_COLOR)
-    .add_modifier(Modifier::BOLD);
-const TEXT_FG_COLOR: Color = SLATE.c50;
-const HEADER_BG_COLOR: Color = SLATE.c800;
-const DIR_TEXT_COLOR: Color = SLATE.c200;
-const NONDIR_TEXT_COLOR: Color = SLATE.c200;
-const LIST_BG_COLOR: Color = SLATE.c950;
-const GAUGE_COLOR: Color = SLATE.c200;
-
-const ERROR_MESSAGE_STYLE: Style = Style::new().fg(RED.c50).bg(RED.c800);
-const WARNING_MESSAGE_STYLE: Style = Style::new().fg(YELLOW.c950).bg(YELLOW.c300);
-const INFO_MESSAGE_STYLE: Style = Style::new().fg(SLATE.c50).bg(SLATE.c950);
-
-const POPUP_FG_COLOR: Color = SLATE.c50;
-const POPUP_BG_COLOR: Color = SLATE.c950;
 pub const POPUP_TEXT_HEIGHT: usize = 10;
 
 const GAUGE_WIDTH: usize = 20;
+/// The colors the interface names, for their meaning rather than their shade.
+/// Everything else is left to the terminal.
+const ERROR_STYLE: Style = Style::new().fg(Color::White).bg(Color::Red);
+const WARNING_STYLE: Style = Style::new().fg(Color::Black).bg(Color::Yellow);
+/// The cursor row names both of its colors, since with the background inherited
+/// neither one alone can be relied on to contrast with it. It shades the background
+/// rather than reversing the row: reversing a gauge swaps its filled and empty
+/// cells, because a `█` reversed is drawn in the background color while a reversed
+/// empty cell paints the foreground across its whole width, so the bar would read
+/// backwards. Grey rather than blue: `Color::Blue` is ANSI 4, already the darkest
+/// blue there is, so on a theme that renders it brightly there is nothing left to
+/// raise the contrast against white with. `DarkGray` is the only named color darker
+/// than blue that won't merge into a dark terminal's own background.
+/// The row is not emboldened as well: bold brightens the text on top of the color
+/// change, which reads as the row lightening rather than being marked.
+const SELECTED_STYLE: Style = Style::new().bg(Color::DarkGray).fg(Color::White);
+
 /// Marks the selected row, and is prepended to every row by the list widget.
 const HIGHLIGHT_SYMBOL: &str = "> ";
 /// Minimum widths of the size and count columns. The unit forms never exceed these,
@@ -52,8 +48,9 @@ const HIGHLIGHT_SYMBOL: &str = "> ";
 const SIZE_WIDTH: usize = 8;
 const RENTRIES_WIDTH: usize = 7;
 
-/// The widths and number formatting a frame's rows share. Measured once from the
-/// whole listing, since a column is only as narrow as its widest value.
+/// What every row in a frame has to agree on: the widths, measured once from the
+/// whole listing since a column is only as narrow as its widest value, and the
+/// number formatting.
 struct Columns {
     gauge: usize,
     size: usize,
@@ -71,8 +68,7 @@ impl App {
     fn render_header(&self, area: Rect, buf: &mut Buffer) {
         Line::from(format!("cephdu v{} ", env!("CARGO_PKG_VERSION")).bold())
             .centered()
-            .bg(TEXT_FG_COLOR)
-            .fg(HEADER_BG_COLOR)
+            .reversed()
             .render(area, buf);
     }
 
@@ -94,10 +90,10 @@ impl App {
             .saturating_sub(2);
         let path = truncate_start(self.cwd.to_str().unwrap_or("[invalid UTF-8]"), budget);
 
-        let title = Line::from(format!(" {} ", path)).fg(TEXT_FG_COLOR).bold();
-        let stats = Line::from(stats).fg(TEXT_FG_COLOR).bold();
+        let title = Line::from(format!(" {} ", path)).bold();
+        let stats = Line::from(stats).bold();
 
-        let helptitle = Line::from(" Press ? for help ").fg(TEXT_FG_COLOR).bold();
+        let helptitle = Line::from(" Press ? for help ").bold();
 
         // Ordering that outlives a keypress needs to be visible, since the listing
         // alone doesn't always reveal it: grouping is invisible when the directories
@@ -120,7 +116,7 @@ impl App {
         let block = Block::bordered()
             .title(title.left_aligned())
             .title(stats.right_aligned())
-            .title_bottom(Line::from(status).fg(TEXT_FG_COLOR).bold().left_aligned())
+            .title_bottom(Line::from(status).bold().left_aligned())
             .title_bottom(helptitle.right_aligned())
             .border_set(border::THICK);
 
@@ -130,18 +126,13 @@ impl App {
             .iter_entries()
             .enumerate()
             .map(|(i, entry)| {
-                entry
-                    .to_listitem(
-                        &cols,
-                        &self.dir_listing.stats,
-                        selected.map(|s| s == i).unwrap_or(false),
-                    )
-                    .fg(TEXT_FG_COLOR)
-                    .bg(if selected.map(|s| s == i).unwrap_or(false) {
-                        SELECTED_BG_COLOR
+                entry.to_listitem(&cols, &self.dir_listing.stats).style(
+                    if selected.map(|s| s == i).unwrap_or(false) {
+                        SELECTED_STYLE
                     } else {
-                        LIST_BG_COLOR
-                    })
+                        Style::new()
+                    },
+                )
             })
             .collect();
 
@@ -160,8 +151,7 @@ impl App {
 
         let list = List::new(items)
             .highlight_symbol(HIGHLIGHT_SYMBOL)
-            .highlight_spacing(HighlightSpacing::Always)
-            .bg(LIST_BG_COLOR);
+            .highlight_spacing(HighlightSpacing::Always);
 
         let width = content_width.max(inner.width as usize);
         self.hscroll = self.hscroll.min(width - inner.width as usize);
@@ -218,9 +208,9 @@ impl App {
         Line::from(message.text.as_str())
             .centered()
             .style(match message.kind {
-                MessageKind::Error => ERROR_MESSAGE_STYLE,
-                MessageKind::Warning => WARNING_MESSAGE_STYLE,
-                MessageKind::Info => INFO_MESSAGE_STYLE,
+                MessageKind::Error => ERROR_STYLE,
+                MessageKind::Warning => WARNING_STYLE,
+                MessageKind::Info => Style::new(),
             })
             .render(area, buf);
     }
@@ -234,33 +224,23 @@ fn render_popup(popup: &mut Popup, areas: [Rect; 2], buf: &mut Buffer) {
     };
 
     let block = Block::default()
-        .title(Span::styled(
-            format!(" {} ", popup.title),
-            Style::default().fg(POPUP_FG_COLOR),
-        ))
+        .title(format!(" {} ", popup.title))
         .borders(Borders::ALL)
-        .border_set(top_border_set)
-        .border_style(Style::default().fg(POPUP_FG_COLOR))
-        .bg(LIST_BG_COLOR);
+        .border_set(top_border_set);
 
     let footer_block = Block::default()
         .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
-        .border_style(Style::default().fg(POPUP_FG_COLOR))
-        .border_set(border::THICK)
-        .bg(LIST_BG_COLOR);
+        .border_set(border::THICK);
 
     let paragraph = Paragraph::new(Text::from(popup.text.as_str()))
         .block(block)
         .wrap(Wrap { trim: false })
         .alignment(Alignment::Center)
-        .bg(POPUP_BG_COLOR)
-        .fg(POPUP_FG_COLOR)
         .scroll((popup.scroll() as u16, 0));
 
     let footer = Paragraph::new(popup.bottom_title.clone())
         .block(footer_block)
-        .centered()
-        .fg(POPUP_FG_COLOR);
+        .centered();
 
     Clear.render(areas[0], buf);
     Clear.render(areas[1], buf);
@@ -297,12 +277,7 @@ fn safe_div(a: usize, b: usize) -> f64 {
 }
 
 impl DirEntry {
-    fn to_listitem(
-        &self,
-        cols: &Columns,
-        listing_stats: &ListingStats,
-        selected: bool,
-    ) -> ListItem<'static> {
+    fn to_listitem(&self, cols: &Columns, listing_stats: &ListingStats) -> ListItem<'static> {
         // The borrow checker complains that self.dir_listing remains borrowed
         // immutably unless we insist on the static lifetime of the ListItem.
         // I'm pretty sure this a borrow checker limitation, rather than a real bug.
@@ -316,66 +291,39 @@ impl DirEntry {
             .rentries
             .map(|r| safe_div(r, listing_stats.total_rentries));
 
-        let text_color = match self.kind {
-            EntryKind::Dir => DIR_TEXT_COLOR,
-            _ => NONDIR_TEXT_COLOR,
-        };
-
         let mut spans: Vec<Span> = vec![];
 
-        let style_selected = |span: Span<'static>| -> Span<'static> {
-            if selected {
-                span.style(SELECTED_STYLE)
-            } else {
-                span
-            }
-        };
-
-        spans.push(style_selected(Span::styled(
-            format!(
-                "{:>width$} ┃",
-                cols.numbers.size(self.size, true),
-                width = cols.size
-            ),
-            text_color,
+        spans.push(Span::raw(format!(
+            "{:>width$} ┃",
+            cols.numbers.size(self.size, true),
+            width = cols.size
         )));
 
-        spans.extend(gauge(
-            size_gauge_fraction,
-            size_gauge_percent,
-            cols.gauge,
-            selected,
-        ));
+        spans.extend(gauge(size_gauge_fraction, size_gauge_percent, cols.gauge));
 
-        spans.push(style_selected(Span::styled(
-            format!(
-                "┃  {:>width$} ┃",
-                cols.numbers.count(self.rentries, true),
-                width = cols.rentries
-            ),
-            text_color,
+        spans.push(Span::raw(format!(
+            "┃  {:>width$} ┃",
+            cols.numbers.count(self.rentries, true),
+            width = cols.rentries
         )));
 
         spans.extend(gauge(
             rentries_gauge_fraction,
             rentries_gauge_percent,
             cols.gauge,
-            selected,
         ));
 
-        spans.push(style_selected(Span::styled("┃", text_color)));
+        spans.push(Span::raw("┃"));
 
         if cols.show_owner {
             if let Some(user) = &self.user {
-                spans.push(style_selected(Span::styled(
-                    format!(" {:>uwidth$}", user, uwidth = cols.user),
-                    text_color,
-                )));
+                spans.push(Span::raw(format!(" {:>uwidth$}", user, uwidth = cols.user)));
             }
             if let Some(group) = &self.group {
-                spans.push(style_selected(Span::styled(
-                    format!(":{:gwidth$}", group, gwidth = cols.group),
-                    text_color,
+                spans.push(Span::raw(format!(
+                    ":{:gwidth$}",
+                    group,
+                    gwidth = cols.group
                 )));
             }
         }
@@ -383,20 +331,14 @@ impl DirEntry {
         if cols.show_ctime
             && let Some(ctime_seconds) = self.ctime
         {
-            spans.push(style_selected(Span::styled(
-                format!(
-                    " {:cwidth$}",
-                    ctime_str(ctime_seconds, cols.current_year),
-                    cwidth = cols.ctime
-                ),
-                text_color,
+            spans.push(Span::raw(format!(
+                " {:cwidth$}",
+                ctime_str(ctime_seconds, cols.current_year),
+                cwidth = cols.ctime
             )));
         }
 
-        spans.push(style_selected(Span::styled(
-            format!(" {}", self.name),
-            text_color,
-        )));
+        spans.push(Span::raw(format!(" {}", self.name)));
 
         let line = Line::from(spans);
         ListItem::new(line)
@@ -405,7 +347,7 @@ impl DirEntry {
 
 /// Draw a unicode gauge bar with a given percentage and width.
 /// The percentage will be written as a number in the middle of the gauge.
-fn gauge(fraction: f64, percent: Option<f64>, width: usize, selected: bool) -> Vec<Span<'static>> {
+fn gauge(fraction: f64, percent: Option<f64>, width: usize) -> Vec<Span<'static>> {
     let text_start = width / 2 - 3;
 
     let count = |filled: f64, width: usize| -> (usize, usize) {
@@ -414,11 +356,14 @@ fn gauge(fraction: f64, percent: Option<f64>, width: usize, selected: bool) -> V
         (whole / 8, eighths)
     };
 
-    let bg_color: Color = if selected {
-        SELECTED_BG_COLOR
-    } else {
-        LIST_BG_COLOR
-    };
+    // The bar is data, so it keeps the terminal's foreground on every row: taking the
+    // cursor row's would leave one bar in the column a different color from its
+    // neighbours. Only the background behind it comes from the row.
+    let bar: Style = Style::new().fg(Color::Reset);
+    // The percentage over the bar swaps the terminal's own pair, not the row's, for
+    // the same reason: reversing the cursor row's blue would put blue text on the
+    // bar, which is only legible on some terminals.
+    let over_bar: Style = bar.bg(Color::Reset).add_modifier(Modifier::REVERSED);
 
     let mut spans = vec![];
 
@@ -434,7 +379,7 @@ fn gauge(fraction: f64, percent: Option<f64>, width: usize, selected: bool) -> V
                 eighths[remainder],
                 " ".repeat(width - whole - (remainder > 0) as usize)
             ),
-            Style::default().fg(GAUGE_COLOR).bg(bg_color),
+            bar,
         )
     };
 
@@ -452,13 +397,13 @@ fn gauge(fraction: f64, percent: Option<f64>, width: usize, selected: bool) -> V
         if split_char > 0 {
             spans.push(Span::styled(
                 percent_text[..split_char.min(text_width)].to_string(),
-                Style::default().bg(GAUGE_COLOR).fg(bg_color),
+                over_bar,
             ));
         }
         if split_char < text_width {
             spans.push(Span::styled(
                 percent_text[split_char..].to_string(),
-                Style::default().fg(GAUGE_COLOR).bg(bg_color),
+                Style::default(),
             ));
         }
 
@@ -603,8 +548,8 @@ mod tests {
         assert_eq!(&lines[1..], EXPECTED, "\n{}", lines.join("\n"));
     }
 
-    /// The row the cursor is on is filled manually rather than by ratatui's
-    /// highlight style, so the fill is worth checking directly.
+    /// The cursor row is shaded and names both of its colors, and the marker still
+    /// points at it.
     #[test]
     fn highlights_the_selected_row() {
         let mut app = app();
@@ -612,9 +557,78 @@ mod tests {
         terminal.draw(|f| ui(f, &mut app)).unwrap();
         let buf = terminal.backend().buffer();
 
-        // Row 2 is "..", the initial selection; row 3 is the first real entry.
-        assert_eq!(buf[(5, 3)].bg, SELECTED_BG_COLOR);
-        assert_eq!(buf[(5, 4)].bg, LIST_BG_COLOR);
+        // Row 3 is "..", the initial selection; row 4 is the first real entry.
+        assert_eq!(buf[(5, 3)].bg, Color::DarkGray);
+        assert_eq!(buf[(5, 3)].fg, Color::White);
+        assert!(!buf[(5, 3)].modifier.contains(Modifier::REVERSED));
+        // The band and the marker are the cue; the row is not emboldened as well,
+        // since bold brightens the text on top of the color change.
+        assert!(!buf[(5, 3)].modifier.contains(Modifier::BOLD));
+
+        assert_eq!(buf[(5, 4)].bg, Color::Reset);
+        assert_eq!(buf[(5, 4)].fg, Color::Reset);
+
+        assert!(frame(&mut app)[3].starts_with("┃>"));
+    }
+
+    /// The percentage sits legibly on the bar by swapping the row's own two colors.
+    /// The bar itself must never be reversed: a reversed `█` is drawn in the
+    /// background color and a reversed empty cell paints the foreground, so the bar
+    /// would show the wrong value.
+    #[test]
+    fn the_gauge_reverses_only_its_percentage() {
+        let mut app = app();
+        let mut terminal = Terminal::new(TestBackend::new(80, 10)).unwrap();
+        terminal.draw(|f| ui(f, &mut app)).unwrap();
+        let buf = terminal.backend().buffer();
+
+        let reversed = |x: u16, y: u16| buf[(x, y)].modifier.contains(Modifier::REVERSED);
+
+        // x=15 is bar with no text over it; x=22 falls inside the percentage. Row 4
+        // is a/, whose bar is full; row 3 is the selected ".." row.
+        for row in [3, 4] {
+            assert!(
+                !reversed(15, row),
+                "the bar itself is reversed on row {}",
+                row
+            );
+        }
+        assert!(
+            reversed(22, 4),
+            "the percentage over the bar is not reversed"
+        );
+    }
+
+    /// Nothing names an absolute color: every cell is either the terminal's own or
+    /// one of the 16 it maps itself, which is what lets the interface suit a light
+    /// terminal as well as a dark one.
+    #[test]
+    fn the_interface_names_no_absolute_colors() {
+        let mut app = app();
+        app.message(Some(Message {
+            text: "Warning: not a Ceph directory".to_string(),
+            kind: MessageKind::Warning,
+        }));
+        app.handle_key(KeyEvent::from(KeyCode::Char('?')));
+
+        let mut terminal = Terminal::new(TestBackend::new(80, 10)).unwrap();
+        terminal.draw(|f| ui(f, &mut app)).unwrap();
+        let buf = terminal.backend().buffer();
+
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                let cell = &buf[(x, y)];
+                for color in [cell.fg, cell.bg] {
+                    assert!(
+                        !matches!(color, Color::Rgb(..) | Color::Indexed(_)),
+                        "{:?} at {},{} is absolute",
+                        color,
+                        x,
+                        y
+                    );
+                }
+            }
+        }
     }
 
     #[test]
@@ -950,6 +964,37 @@ mod tests {
                 budget
             );
         }
+    }
+
+    /// A bar is data, so it looks the same whichever row the cursor is on: only the
+    /// background behind it comes from the row.
+    #[test]
+    fn the_gauge_keeps_its_colors_on_the_cursor_row() {
+        let mut app = app();
+        app.handle_key(KeyEvent::from(KeyCode::Down));
+
+        let mut terminal = Terminal::new(TestBackend::new(80, 10)).unwrap();
+        terminal.draw(|f| ui(f, &mut app)).unwrap();
+        let buf = terminal.backend().buffer();
+
+        // Row 4 is a/, now the cursor row; row 5 is b/. Both have bar under x=46 and
+        // under the percentage at x=52, in the second gauge.
+        for x in [46, 52] {
+            assert_eq!(
+                buf[(x, 4)].fg,
+                buf[(x, 5)].fg,
+                "x={} is a different color on the cursor row",
+                x
+            );
+            assert_eq!(buf[(x, 4)].modifier, buf[(x, 5)].modifier, "x={}", x);
+        }
+
+        // The row still shades behind the bar, but not behind the percentage, which
+        // reverses the terminal's own pair so it reads on any of them.
+        assert_eq!(buf[(46, 4)].bg, Color::DarkGray);
+        assert_eq!(buf[(46, 5)].bg, Color::Reset);
+        assert_eq!(buf[(52, 4)].bg, Color::Reset);
+        assert_eq!(buf[(52, 5)].bg, Color::Reset);
     }
 
     /// The status area lives in the bottom border and must not disturb the rest of it.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -480,7 +480,9 @@ pub fn ui(frame: &mut Frame, app: &mut App) {
     app.render_header(header_area, frame.buffer_mut());
     app.render_list(main_area, frame.buffer_mut());
 
-    app.render_message(&app.message, message_area, frame.buffer_mut());
+    // A read in progress outranks whatever message was up before it.
+    let message = app.progress().or_else(|| app.message.clone());
+    app.render_message(&message, message_area, frame.buffer_mut());
 
     if let Some(popup) = &mut app.popup {
         let popup_areas = popup_rects(
@@ -521,11 +523,13 @@ mod tests {
         ]
     }
 
-    /// An app whose listing is synthetic, so the frame doesn't depend on the
-    /// filesystem the tests happen to run on. The cwd is faked for the same reason;
-    /// App::new only needs a readable directory to start from.
+    /// An app whose listing is synthetic and whose cwd is faked, so the frame
+    /// doesn't depend on the filesystem the tests happen to run on -- App::new
+    /// itself reads nothing. The receiver is dropped, which is fine because these
+    /// tests never dispatch a read: the listing already has owners and times, so
+    /// even `u` and `t` have nothing to fetch.
     fn app() -> App {
-        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
+        let (mut app, _listings) = App::new(Options::default());
         app.cwd = PathBuf::from("/ceph/users/alice");
         app.dir_listing = DirListing::from_entries(
             entries(),
@@ -533,13 +537,10 @@ mod tests {
             Options {
                 sort_mode: DEFAULT_SORT_MODE,
                 dirs_first: false,
-                // The entries carry owners and times, so this listing was read with
-                // both and pressing `u` or `t` has nothing to fetch.
                 owners: true,
                 times: true,
             },
         );
-        app.message(None);
         app
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -435,8 +435,8 @@ mod tests {
     use ratatui::backend::TestBackend;
     use std::path::PathBuf;
 
-    fn entries() -> Vec<DirEntry> {
-        let entry = |name: &str, kind, size, rentries| DirEntry {
+    fn entry(name: &str, kind: EntryKind, size: usize, rentries: Option<usize>) -> DirEntry {
+        DirEntry {
             name: name.to_string(),
             kind,
             size: Some(size),
@@ -444,7 +444,10 @@ mod tests {
             ctime: Some(992_606_400),
             user: Some("alice".to_string()),
             group: Some("scc".to_string()),
-        };
+        }
+    }
+
+    fn entries() -> Vec<DirEntry> {
         vec![
             entry("a/", EntryKind::Dir, 800_000_000_000, Some(60_000)),
             entry("b/", EntryKind::Dir, 200_000_000_000, Some(40_000)),
@@ -456,9 +459,9 @@ mod tests {
     /// filesystem the tests happen to run on. The cwd is faked for the same reason;
     /// App::new only needs a readable directory to start from.
     fn app() -> App {
-        let mut app = App::new(Some(&PathBuf::from(".")), DEFAULT_SORT_MODE).unwrap();
+        let mut app = App::new(Some(&PathBuf::from(".")), DEFAULT_SORT_MODE, false).unwrap();
         app.cwd = PathBuf::from("/ceph/users/alice");
-        app.dir_listing = DirListing::from_entries(entries(), true, DEFAULT_SORT_MODE);
+        app.dir_listing = DirListing::from_entries(entries(), true, DEFAULT_SORT_MODE, false);
         app.message(None);
         app
     }
@@ -585,6 +588,40 @@ mod tests {
         app.handle_key(KeyEvent::from(KeyCode::Char('n')));
         assert_eq!(app.dir_listing.sort_mode(), SortField::Name.default_mode());
         assert_eq!(names(&mut app), ["a/", "b/", "c.dat"]);
+    }
+
+    /// The default fixture can't show this: its directories are already the largest.
+    #[test]
+    fn dirs_first_key_regroups_the_rows() {
+        let mut app = app();
+        app.dir_listing = DirListing::from_entries(
+            vec![
+                entry("a/", EntryKind::Dir, 100_000, Some(1)),
+                entry("big.dat", EntryKind::File, 999_000, None),
+            ],
+            true,
+            DEFAULT_SORT_MODE,
+            false,
+        );
+
+        let names = |app: &mut App| -> Vec<String> {
+            frame(app)[4..6]
+                .iter()
+                .map(|l| l.split('┃').nth(5).unwrap().trim().to_string())
+                .collect()
+        };
+
+        assert_eq!(names(&mut app), ["big.dat", "a/"]);
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('d')));
+        assert_eq!(names(&mut app), ["a/", "big.dat"], "'d' did not regroup");
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('d')));
+        assert_eq!(
+            names(&mut app),
+            ["big.dat", "a/"],
+            "'d' did not toggle back"
+        );
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -67,8 +67,27 @@ impl App {
 
         let helptitle = Line::from(" Press ? for help ").fg(TEXT_FG_COLOR).bold();
 
+        // Ordering that outlives a keypress needs to be visible, since the listing
+        // alone doesn't always reveal it: grouping is invisible when the directories
+        // happen to sort first anyway, and two fields can agree on an order.
+        let sort_mode = self.dir_listing.sort_mode();
+        let mut status = format!(
+            " {} {}",
+            sort_mode.field().label(),
+            if sort_mode.is_reversed() {
+                "↓"
+            } else {
+                "↑"
+            }
+        );
+        if self.dir_listing.dirs_first() {
+            status.push_str(" · dirs first");
+        }
+        status.push(' ');
+
         let block = Block::bordered()
             .title(title.left_aligned())
+            .title_bottom(Line::from(status).fg(TEXT_FG_COLOR).bold().left_aligned())
             .title_bottom(helptitle.right_aligned())
             .border_set(border::THICK);
 
@@ -495,7 +514,7 @@ mod tests {
         "┃    1.0 MB ┃         0.0%       ┃          ┃                    ┃ c.dat       ┃",
         "┃                                                                              ┃",
         "┃                                                                              ┃",
-        "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Press ? for help ┛",
+        "┗ size ↓ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Press ? for help ┛",
     ];
 
     #[test]
@@ -590,6 +609,37 @@ mod tests {
         assert_eq!(names(&mut app), ["a/", "b/", "c.dat"]);
     }
 
+    /// The status area names the field and points the way the values run.
+    #[test]
+    fn the_status_area_tracks_the_sort() {
+        let mut app = app();
+        let status = |app: &mut App| -> String {
+            let border = frame(app).last().unwrap().clone();
+            border
+                .trim_start_matches('┗')
+                .split('━')
+                .next()
+                .unwrap()
+                .trim()
+                .to_string()
+        };
+
+        assert_eq!(status(&mut app), "size ↓", "the default is largest first");
+
+        // Same field again reverses it.
+        app.handle_key(KeyEvent::from(KeyCode::Char('s')));
+        assert_eq!(status(&mut app), "size ↑");
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('n')));
+        assert_eq!(status(&mut app), "name ↑");
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('c')));
+        assert_eq!(status(&mut app), "count ↓");
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('d')));
+        assert_eq!(status(&mut app), "count ↓ · dirs first");
+    }
+
     /// The default fixture can't show this: its directories are already the largest.
     #[test]
     fn dirs_first_key_regroups_the_rows() {
@@ -611,10 +661,14 @@ mod tests {
                 .collect()
         };
 
+        let shows_indicator = |app: &mut App| frame(app).join("\n").contains("dirs first");
+
         assert_eq!(names(&mut app), ["big.dat", "a/"]);
+        assert!(!shows_indicator(&mut app), "indicator shown while off");
 
         app.handle_key(KeyEvent::from(KeyCode::Char('d')));
         assert_eq!(names(&mut app), ["a/", "big.dat"], "'d' did not regroup");
+        assert!(shows_indicator(&mut app), "no indicator while grouping");
 
         app.handle_key(KeyEvent::from(KeyCode::Char('d')));
         assert_eq!(
@@ -622,6 +676,28 @@ mod tests {
             ["big.dat", "a/"],
             "'d' did not toggle back"
         );
+        assert!(!shows_indicator(&mut app), "indicator outlived the mode");
+    }
+
+    /// The status area lives in the bottom border and must not disturb the rest of it.
+    #[test]
+    fn dirs_first_indicator_shares_the_bottom_border() {
+        let mut app = app();
+        let plain = frame(&mut app);
+
+        app.dir_listing.toggle_dirs_first();
+        let grouped = frame(&mut app);
+
+        assert_eq!(
+            grouped[..grouped.len() - 1],
+            plain[..plain.len() - 1],
+            "the indicator changed a row other than the bottom border"
+        );
+
+        let border = grouped.last().unwrap();
+        assert!(border.contains("dirs first"), "{}", border);
+        assert!(border.contains("Press ? for help"), "{}", border);
+        assert_eq!(border.chars().count(), 80, "{}", border);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,6 +15,7 @@ use chrono::{Datelike, Local};
 
 use crate::app::App;
 use crate::app::DirEntry;
+use crate::app::InfoStats;
 use crate::app::ListingStats;
 use crate::app::Message;
 use crate::app::MessageKind;
@@ -124,32 +125,25 @@ impl App {
         let title = Line::from(format!(" {} ", path)).bold();
         let stats = Line::from(stats).bold();
 
-        let helptitle = Line::from(" Press ? for help ").bold();
-
-        // Ordering that outlives a keypress needs to be visible, since the listing
-        // alone doesn't always reveal it: grouping is invisible when the directories
-        // happen to sort first anyway, and two fields can agree on an order.
-        let sort_mode = self.dir_listing.sort_mode();
-        let mut status = format!(
-            " {} {}",
-            sort_mode.field().label(),
-            if sort_mode.is_reversed() {
-                "↓"
-            } else {
-                "↑"
-            }
-        );
-        if self.dir_listing.dirs_first() {
-            status.push_str(" · dirs first");
-        }
-        status.push(' ');
-
+        // With the info panel below, the bottom border is a divider the panel's
+        // sides run through, so its corners become connectors -- and the status
+        // titles move down to the panel's bottom border, staying the frame's
+        // footer wherever that is.
         let block = Block::bordered()
             .title(title.left_aligned())
-            .title(stats.right_aligned())
-            .title_bottom(Line::from(status).bold().left_aligned())
-            .title_bottom(helptitle.right_aligned())
-            .border_set(border::THICK);
+            .title(stats.right_aligned());
+        let block = if self.info.is_some() {
+            block.border_set(symbols::border::Set {
+                bottom_left: symbols::line::THICK.vertical_right,
+                bottom_right: symbols::line::THICK.vertical_left,
+                ..border::THICK
+            })
+        } else {
+            block
+                .title_bottom(self.status_line().left_aligned())
+                .title_bottom(help_hint().right_aligned())
+                .border_set(border::THICK)
+        };
 
         let selected = self.dir_listing.selected();
         let items: Vec<ListItem> = self
@@ -195,6 +189,47 @@ impl App {
                 buf[(inner.x + x, inner.y + y)] = rows[((self.hscroll as u16) + x, y)].clone();
             }
         }
+    }
+
+    /// The panel under the listing, whose bottom border serves as its top and
+    /// carries the footer titles while it is open.
+    fn render_info(&self, rows: &[(&'static str, String)], area: Rect, buf: &mut Buffer) {
+        let block = Block::default()
+            .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+            .border_set(border::THICK)
+            .title_bottom(self.status_line().left_aligned())
+            .title_bottom(help_hint().right_aligned());
+
+        let lhs = rows.iter().map(|(l, _)| l.len()).max().unwrap_or(0);
+        let text = rows
+            .iter()
+            .map(|(label, value)| format!(" {:>lhs$}:  {}", label, value))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        Paragraph::new(text).block(block).render(area, buf);
+    }
+
+    /// The footer's left half. Ordering that outlives a keypress needs to be
+    /// visible, since the listing alone doesn't always reveal it: grouping is
+    /// invisible when the directories happen to sort first anyway, and two
+    /// fields can agree on an order.
+    fn status_line(&self) -> Line<'static> {
+        let sort_mode = self.dir_listing.sort_mode();
+        let mut status = format!(
+            " {} {}",
+            sort_mode.field().label(),
+            if sort_mode.is_reversed() {
+                "↓"
+            } else {
+                "↑"
+            }
+        );
+        if self.dir_listing.dirs_first() {
+            status.push_str(" · dirs first");
+        }
+        status.push(' ');
+        Line::from(status).bold()
     }
 
     fn columns(&self) -> Columns {
@@ -246,6 +281,90 @@ impl App {
             })
             .render(area, buf);
     }
+}
+
+/// The info panel's rows. Which lines exist depends on what the filesystem
+/// provides, so the panel's height does too.
+fn info_rows(stats: &InfoStats, numbers: Numbers) -> Vec<(&'static str, String)> {
+    let size = |b: usize| numbers.size(Some(b), false);
+    let count = |n: usize| numbers.count(Some(n), false);
+
+    let mut rows: Vec<(&'static str, String)> = Vec::new();
+    if let Some(rbytes) = stats.rbytes {
+        rows.push(("Recursive size", size(rbytes)));
+    }
+    if let (Some(rentries), Some(rfiles), Some(rsubdirs)) =
+        (stats.rentries, stats.rfiles, stats.rsubdirs)
+    {
+        rows.push((
+            "Recursive entries",
+            format!(
+                "{} ({} files, {} dirs)",
+                count(rentries),
+                count(rfiles),
+                count(rsubdirs)
+            ),
+        ));
+    }
+    // The means are recursive too -- the label says so, since these sit nearest
+    // the this-level rows and position alone would suggest the wrong scope.
+    if let (Some(rbytes), Some(rfiles)) = (stats.rbytes, stats.rfiles)
+        && rfiles > 0
+    {
+        rows.push(("Recursive mean file size", size(rbytes / rfiles)));
+    }
+    // What a heavily-loaded MDS wants kept low. The divisor includes this
+    // directory as one of the directories, so a flat directory of N entries
+    // reads N per directory rather than dividing by zero; the numerator needs
+    // no such care, since only rsubdirs self-counts and it arrives here
+    // already subtracted.
+    if let (Some(rentries), Some(rsubdirs)) = (stats.rentries, stats.rsubdirs) {
+        rows.push((
+            "Recursive entries per dir",
+            format!("{:.1}", rentries as f64 / (rsubdirs + 1) as f64),
+        ));
+    }
+    let share = |level: usize, recursive: Option<usize>| match recursive {
+        Some(recursive) if recursive > 0 => {
+            format!(
+                "{:.1}% of recursive",
+                level as f64 / recursive as f64 * 100.0
+            )
+        }
+        _ => String::new(),
+    };
+
+    let size_share = share(stats.level_bytes, stats.rbytes);
+    rows.push((
+        "Size at this level",
+        if size_share.is_empty() {
+            size(stats.level_bytes)
+        } else {
+            format!("{} ({})", size(stats.level_bytes), size_share)
+        },
+    ));
+    // The share joins the parenthetical rather than trailing as a second one.
+    let entries_share = share(stats.level_files + stats.level_dirs, stats.rentries);
+    let entries_share = if entries_share.is_empty() {
+        entries_share
+    } else {
+        format!(", {}", entries_share)
+    };
+    rows.push((
+        "Entries at this level",
+        format!(
+            "{} ({} files, {} dirs{})",
+            count(stats.level_files + stats.level_dirs),
+            count(stats.level_files),
+            count(stats.level_dirs),
+            entries_share
+        ),
+    ));
+    rows
+}
+
+fn help_hint() -> Line<'static> {
+    Line::from(" Press ? for help ").bold()
 }
 
 fn render_popup(popup: &mut Popup, areas: [Rect; 2], buf: &mut Buffer) {
@@ -487,15 +606,25 @@ fn popup_rects(xsize: u16, ysize: u16, r: Rect) -> [Rect; 2] {
 }
 
 pub fn ui(frame: &mut Frame, app: &mut App) {
-    let [header_area, message_area, main_area] = Layout::vertical([
+    let rows = app
+        .info
+        .as_ref()
+        .map(|stats| info_rows(stats, Numbers::from_exact(app.exact)));
+    let panel_height = rows.as_ref().map_or(0, |rows| rows.len() as u16 + 1);
+
+    let [header_area, message_area, main_area, info_area] = Layout::vertical([
         Constraint::Length(1),
         Constraint::Length(1),
         Constraint::Fill(1),
+        Constraint::Length(panel_height),
     ])
     .areas(frame.area());
 
     app.render_header(header_area, frame.buffer_mut());
     app.render_list(main_area, frame.buffer_mut());
+    if let Some(rows) = &rows {
+        app.render_info(rows, info_area, frame.buffer_mut());
+    }
 
     // A read in progress outranks whatever message was up before it.
     let message = app.progress().or_else(|| app.message.clone());
@@ -1116,6 +1245,109 @@ mod tests {
         assert!(border.contains("dirs first"), "{}", border);
         assert!(border.contains("Press ? for help"), "{}", border);
         assert_eq!(border.chars().count(), 80, "{}", border);
+    }
+
+    /// The rows a Ceph directory gets, from synthetic stats so every branch is
+    /// certain: both this-level rows carry their share of the recursive value.
+    #[test]
+    fn info_rows_price_this_level_against_recursive() {
+        let stats = InfoStats {
+            level_bytes: 250,
+            level_files: 3,
+            level_dirs: 2,
+            rbytes: Some(1_000),
+            rentries: Some(50),
+            rfiles: Some(40),
+            rsubdirs: Some(10),
+        };
+        let rows = info_rows(&stats, Numbers::Exact);
+        let row = |label: &str| {
+            rows.iter()
+                .find(|(l, _)| *l == label)
+                .unwrap_or_else(|| panic!("no {:?} row in {:?}", label, rows))
+                .1
+                .clone()
+        };
+
+        assert_eq!(row("Size at this level"), "250 (25.0% of recursive)");
+        assert_eq!(
+            row("Entries at this level"),
+            "5 (3 files, 2 dirs, 10.0% of recursive)"
+        );
+        assert_eq!(row("Recursive entries"), "50 (40 files, 10 dirs)");
+        assert_eq!(row("Recursive mean file size"), "25");
+        // Divides by the 10 subdirs plus this directory itself; the 50 entries
+        // are everything beneath it, self already excluded.
+        assert_eq!(row("Recursive entries per dir"), "4.5");
+        assert!(
+            !rows.iter().any(|(l, _)| l.contains("files per dir")),
+            "{:?}",
+            rows
+        );
+
+        // Off Ceph the recursive rows and the shares disappear.
+        let rows = info_rows(
+            &InfoStats {
+                rbytes: None,
+                rentries: None,
+                rfiles: None,
+                rsubdirs: None,
+                ..stats
+            },
+            Numbers::Exact,
+        );
+        assert_eq!(rows.len(), 2, "{:?}", rows);
+        assert!(!rows[0].1.contains('%'), "{:?}", rows);
+    }
+
+    /// The info panel on the synthetic listing: no filesystem, so the recursive
+    /// lines are absent and this level is computed from the entries in hand --
+    /// one 1.0 MB file beside two directories.
+    #[test]
+    fn the_info_panel_reports_this_level() {
+        let mut app = app();
+        app.handle_key(KeyEvent::from(KeyCode::Char('i')));
+
+        let lines = frame_sized(&mut app, 80, 24);
+        let text = lines.join("\n");
+        assert!(text.contains("Size at this level"), "{}", text);
+        assert!(text.contains("1.0 MB"), "{}", text);
+        assert!(text.contains("(1 files, 2 dirs)"), "{}", text);
+        assert!(
+            !text.contains("Recursive"),
+            "recursive lines appeared without a filesystem:\n{}",
+            text
+        );
+        // The panel hangs off the listing's bottom border, so that border's
+        // corners become connectors and the panel's own bottom closes the frame.
+        let divider = lines
+            .iter()
+            .find(|l| l.starts_with('┣'))
+            .expect("no connected divider");
+        assert!(
+            !divider.contains("size") && !divider.contains("help"),
+            "the footer titles stayed on the divider: {}",
+            divider
+        );
+        // The footer belongs to the frame's bottom, wherever that is.
+        let bottom = lines.last().unwrap();
+        assert!(
+            bottom.starts_with('┗'),
+            "the panel does not close the frame"
+        );
+        assert!(
+            bottom.contains("size ↓") && bottom.contains("Press ? for help"),
+            "the footer titles are not on the bottom border: {}",
+            bottom
+        );
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('i')));
+        let text = frame_sized(&mut app, 80, 24).join("\n");
+        assert!(
+            !text.contains("at this level"),
+            "i did not close the panel:\n{}",
+            text
+        );
     }
 
     /// The popup shows as much of its text as the terminal has room for, so on a

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -40,6 +40,24 @@ const WARNING_STYLE: Style = Style::new().fg(Color::Black).bg(Color::Yellow);
 /// The row is not emboldened as well: bold brightens the text on top of the color
 /// change, which reads as the row lightening rather than being marked.
 const SELECTED_STYLE: Style = Style::new().bg(Color::DarkGray).fg(Color::White);
+/// What is left when colors are off. crossterm drops every color sequence under
+/// NO_COLOR but still sends attributes, so a band made only of colors vanishes and
+/// the row would be marked by nothing but the marker.
+const SELECTED_STYLE_NO_COLOR: Style = Style::new().add_modifier(Modifier::BOLD);
+
+/// no-color.org: set and non-empty. crossterm reads the same variable to decide
+/// whether to emit color sequences at all.
+fn colors_disabled() -> bool {
+    std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty())
+}
+
+const fn selected_style(colors_disabled: bool) -> Style {
+    if colors_disabled {
+        SELECTED_STYLE_NO_COLOR
+    } else {
+        SELECTED_STYLE
+    }
+}
 
 /// Marks the selected row, and is prepended to every row by the list widget.
 const HIGHLIGHT_SYMBOL: &str = "> ";
@@ -52,6 +70,8 @@ const RENTRIES_WIDTH: usize = 7;
 /// whole listing since a column is only as narrow as its widest value, and the
 /// number formatting.
 struct Columns {
+    /// How the cursor row is marked, which depends on whether colors are allowed.
+    selected: Style,
     gauge: usize,
     size: usize,
     rentries: usize,
@@ -128,7 +148,7 @@ impl App {
             .map(|(i, entry)| {
                 entry.to_listitem(&cols, &self.dir_listing.stats).style(
                     if selected.map(|s| s == i).unwrap_or(false) {
-                        SELECTED_STYLE
+                        cols.selected
                     } else {
                         Style::new()
                     },
@@ -187,6 +207,7 @@ impl App {
         };
 
         Columns {
+            selected: selected_style(colors_disabled()),
             gauge: GAUGE_WIDTH,
             size: SIZE_WIDTH.max(widest(&|e| numbers.size(e.size, true))),
             rentries: RENTRIES_WIDTH.max(widest(&|e| numbers.count(e.rentries, true))),
@@ -356,10 +377,13 @@ fn gauge(fraction: f64, percent: Option<f64>, width: usize) -> Vec<Span<'static>
         (whole / 8, eighths)
     };
 
-    // The bar is data, so it keeps the terminal's foreground on every row: taking the
-    // cursor row's would leave one bar in the column a different color from its
-    // neighbours. Only the background behind it comes from the row.
-    let bar: Style = Style::new().fg(Color::Reset);
+    // The bar is data, so it keeps the terminal's own rendering on every row: taking
+    // the cursor row's foreground, or the bold it falls back to when colors are off,
+    // would leave one bar in the column looking different from its neighbours. Only
+    // the background behind it comes from the row.
+    let bar: Style = Style::new()
+        .fg(Color::Reset)
+        .remove_modifier(Modifier::BOLD);
     // The percentage over the bar swaps the terminal's own pair, not the row's, for
     // the same reason: reversing the cursor row's blue would put blue text on the
     // bar, which is only legible on some terminals.
@@ -557,13 +581,19 @@ mod tests {
         terminal.draw(|f| ui(f, &mut app)).unwrap();
         let buf = terminal.backend().buffer();
 
-        // Row 3 is "..", the initial selection; row 4 is the first real entry.
-        assert_eq!(buf[(5, 3)].bg, Color::DarkGray);
-        assert_eq!(buf[(5, 3)].fg, Color::White);
+        // Row 3 is "..", the initial selection; row 4 is the first real entry. The
+        // expected style is read rather than named, so the test holds under NO_COLOR.
+        let expected = selected_style(colors_disabled());
+        assert_eq!(buf[(5, 3)].bg, expected.bg.unwrap_or(Color::Reset));
+        assert_eq!(buf[(5, 3)].fg, expected.fg.unwrap_or(Color::Reset));
         assert!(!buf[(5, 3)].modifier.contains(Modifier::REVERSED));
         // The band and the marker are the cue; the row is not emboldened as well,
-        // since bold brightens the text on top of the color change.
-        assert!(!buf[(5, 3)].modifier.contains(Modifier::BOLD));
+        // since bold brightens the text on top of the color change. With colors off
+        // that is inverted: bold is all that is left.
+        assert_eq!(
+            buf[(5, 3)].modifier.contains(Modifier::BOLD),
+            expected.add_modifier.contains(Modifier::BOLD),
+        );
 
         assert_eq!(buf[(5, 4)].bg, Color::Reset);
         assert_eq!(buf[(5, 4)].fg, Color::Reset);
@@ -597,6 +627,20 @@ mod tests {
             reversed(22, 4),
             "the percentage over the bar is not reversed"
         );
+    }
+
+    /// With colors off, the band would be dropped by crossterm and the row left with
+    /// nothing but the marker, so it falls back to an attribute instead.
+    #[test]
+    fn the_cursor_row_survives_no_color() {
+        let colored = selected_style(false);
+        assert_eq!(colored.bg, Some(Color::DarkGray));
+        assert_eq!(colored.fg, Some(Color::White));
+
+        let plain = selected_style(true);
+        assert_eq!(plain.bg, None, "a color that NO_COLOR would drop");
+        assert_eq!(plain.fg, None, "a color that NO_COLOR would drop");
+        assert!(plain.add_modifier.contains(Modifier::BOLD));
     }
 
     /// Nothing names an absolute color: every cell is either the terminal's own or
@@ -991,7 +1035,8 @@ mod tests {
 
         // The row still shades behind the bar, but not behind the percentage, which
         // reverses the terminal's own pair so it reads on any of them.
-        assert_eq!(buf[(46, 4)].bg, Color::DarkGray);
+        let band = selected_style(colors_disabled()).bg.unwrap_or(Color::Reset);
+        assert_eq!(buf[(46, 4)].bg, band);
         assert_eq!(buf[(46, 5)].bg, Color::Reset);
         assert_eq!(buf[(52, 4)].bg, Color::Reset);
         assert_eq!(buf[(52, 5)].bg, Color::Reset);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -512,6 +512,8 @@ mod tests {
             ctime: Some(992_606_400),
             user: Some("alice".to_string()),
             group: Some("scc".to_string()),
+            uid: None,
+            gid: None,
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -429,7 +429,7 @@ pub fn ui(frame: &mut Frame, app: &mut App) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{App, DEFAULT_SORT_MODE, DirListing, EntryKind};
+    use crate::app::{App, DEFAULT_SORT_MODE, DirListing, EntryKind, SortField};
     use crossterm::event::{KeyCode, KeyEvent};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
@@ -456,7 +456,7 @@ mod tests {
     /// filesystem the tests happen to run on. The cwd is faked for the same reason;
     /// App::new only needs a readable directory to start from.
     fn app() -> App {
-        let mut app = App::new(Some(&PathBuf::from("."))).unwrap();
+        let mut app = App::new(Some(&PathBuf::from(".")), DEFAULT_SORT_MODE).unwrap();
         app.cwd = PathBuf::from("/ceph/users/alice");
         app.dir_listing = DirListing::from_entries(entries(), true, DEFAULT_SORT_MODE);
         app.message(None);
@@ -581,7 +581,9 @@ mod tests {
         app.handle_key(KeyEvent::from(KeyCode::Char('s')));
         assert_eq!(names(&mut app), ["c.dat", "b/", "a/"]);
 
+        // The key and the -n flag resolve to the same mode.
         app.handle_key(KeyEvent::from(KeyCode::Char('n')));
+        assert_eq!(app.dir_listing.sort_mode(), SortField::Name.default_mode());
         assert_eq!(names(&mut app), ["a/", "b/", "c.dat"]);
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -495,7 +495,7 @@ pub fn ui(frame: &mut Frame, app: &mut App) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{App, DEFAULT_SORT_MODE, DirListing, EntryKind, SortField};
+    use crate::app::{App, DEFAULT_SORT_MODE, DirListing, EntryKind, Options, SortField};
     use crossterm::event::{KeyCode, KeyEvent};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
@@ -525,9 +525,20 @@ mod tests {
     /// filesystem the tests happen to run on. The cwd is faked for the same reason;
     /// App::new only needs a readable directory to start from.
     fn app() -> App {
-        let mut app = App::new(Some(&PathBuf::from(".")), DEFAULT_SORT_MODE, false).unwrap();
+        let mut app = App::new(Some(&PathBuf::from(".")), Options::default()).unwrap();
         app.cwd = PathBuf::from("/ceph/users/alice");
-        app.dir_listing = DirListing::from_entries(entries(), true, DEFAULT_SORT_MODE, false);
+        app.dir_listing = DirListing::from_entries(
+            entries(),
+            true,
+            Options {
+                sort_mode: DEFAULT_SORT_MODE,
+                dirs_first: false,
+                // The entries carry owners and times, so this listing was read with
+                // both and pressing `u` or `t` has nothing to fetch.
+                owners: true,
+                times: true,
+            },
+        );
         app.message(None);
         app
     }
@@ -786,8 +797,7 @@ mod tests {
                 entry("big.dat", EntryKind::File, 999_000, None),
             ],
             true,
-            DEFAULT_SORT_MODE,
-            false,
+            Options::default(),
         );
 
         let names = |app: &mut App| -> Vec<String> {
@@ -1052,8 +1062,7 @@ mod tests {
                 entry("plain", EntryKind::File, 9, None),
             ],
             true,
-            DEFAULT_SORT_MODE,
-            false,
+            Options::default(),
         );
 
         let names: Vec<String> = frame(&mut app)[4..6]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -14,7 +14,7 @@ use ratatui::{
     },
 };
 
-use chrono::{DateTime, Datelike, Local};
+use chrono::{Datelike, Local};
 
 use crate::app::App;
 use crate::app::DirEntry;
@@ -22,6 +22,7 @@ use crate::app::EntryKind;
 use crate::app::ListingStats;
 use crate::app::Message;
 use crate::app::MessageKind;
+use crate::format::{CTIME_FMT_WIDTH, ctime_str, rentries_str, size_str};
 use crate::popup::Popup;
 
 const SELECTED_BG_COLOR: Color = SLATE.c700;
@@ -44,8 +45,6 @@ const POPUP_BG_COLOR: Color = SLATE.c950;
 pub const POPUP_TEXT_HEIGHT: usize = 10;
 
 const GAUGE_WIDTH: usize = 20;
-// This should be constant: 'Jan  1  2000' or 'Dec 31 12:34'
-const CTIME_FMT_WIDTH: usize = 12;
 
 impl App {
     fn render_header(&self, area: Rect, buf: &mut Buffer) {
@@ -287,19 +286,10 @@ impl DirEntry {
         }
 
         if show_ctime && let Some(ctime_seconds) = self.ctime {
-            let ctime: DateTime<Local> =
-                DateTime::from_timestamp_secs(ctime_seconds.try_into().unwrap_or(0))
-                    .unwrap()
-                    .into();
-            let fmt = if (ctime.year() as isize) == current_year {
-                "%b %e %H:%M"
-            } else {
-                "%b %e  %Y"
-            };
             spans.push(style_selected(Span::styled(
                 format!(
                     " {:cwidth$}",
-                    ctime.format(fmt).to_string(),
+                    ctime_str(ctime_seconds, current_year),
                     cwidth = ctime_width
                 ),
                 text_color,
@@ -386,51 +376,6 @@ fn gauge(fraction: f64, percent: Option<f64>, width: usize, selected: bool) -> V
     spans.push(subgauge(remaining_filled, remaining_width));
 
     spans
-}
-
-fn size_str(size: Option<usize>, align: bool) -> String {
-    if size.is_none() {
-        return "".to_string();
-    }
-    let size = size.unwrap();
-    let units = [" B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
-    let base: usize = 1000;
-    let i = if size > 0 {
-        size.ilog10() / base.ilog10()
-    } else {
-        0
-    };
-    let size = size as f64 / base.pow(i) as f64;
-    if i == 0 {
-        format!(
-            "{:.0}{}{}",
-            size,
-            if align { "  " } else { "" },
-            units[i as usize]
-        )
-    } else {
-        format!("{:.1} {}", size, units[i as usize])
-    }
-}
-
-fn rentries_str(rentries: Option<usize>, align: bool) -> String {
-    if rentries.is_none() {
-        return "".to_string();
-    }
-    let rentries = rentries.unwrap();
-    let units = ["", "K", "M", "G", "T", "P", "E", "Z", "Y"];
-    let base: usize = 1000;
-    let i = if rentries > 0 {
-        rentries.ilog10() / base.ilog10()
-    } else {
-        0
-    };
-    let rentries = rentries as f64 / base.pow(i) as f64;
-    if i == 0 {
-        format!("{:.0}{}", rentries, if align { "    " } else { "" })
-    } else {
-        format!("{:.1} {}", rentries, units[i as usize])
-    }
 }
 
 fn popup_rects(xsize: u16, ysize: u16, r: Rect) -> [Rect; 2] {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -539,6 +539,7 @@ mod tests {
                 dirs_first: false,
                 owners: true,
                 times: true,
+                jobs: 1,
             },
         );
         app

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -22,7 +22,7 @@ use crate::app::EntryKind;
 use crate::app::ListingStats;
 use crate::app::Message;
 use crate::app::MessageKind;
-use crate::format::{CTIME_FMT_WIDTH, ctime_str, rentries_str, size_str};
+use crate::format::{CTIME_FMT_WIDTH, Numbers, ctime_str};
 use crate::popup::Popup;
 
 const SELECTED_BG_COLOR: Color = SLATE.c700;
@@ -45,13 +45,21 @@ const POPUP_BG_COLOR: Color = SLATE.c950;
 pub const POPUP_TEXT_HEIGHT: usize = 10;
 
 const GAUGE_WIDTH: usize = 20;
+/// Minimum widths of the size and count columns. The unit forms never exceed these,
+/// so only exact values widen them.
+const SIZE_WIDTH: usize = 8;
+const RENTRIES_WIDTH: usize = 7;
+
 /// The widths and number formatting a frame's rows share. Measured once from the
 /// whole listing, since a column is only as narrow as its widest value.
 struct Columns {
     gauge: usize,
+    size: usize,
+    rentries: usize,
     user: usize,
     group: usize,
     ctime: usize,
+    numbers: Numbers,
     current_year: isize,
     show_owner: bool,
     show_ctime: bool,
@@ -68,12 +76,13 @@ impl App {
 
     fn render_list(&mut self, area: Rect, buf: &mut Buffer) {
         let cols = self.columns();
+        let numbers = cols.numbers;
 
         let title = Line::from(format!(
             " {} ━━ {}, {} files ",
             self.cwd.to_str().unwrap_or("[invalid UTF-8]"),
-            size_str(Some(self.dir_listing.stats.total_size), false),
-            rentries_str(Some(self.dir_listing.stats.total_rentries), false)
+            numbers.size(Some(self.dir_listing.stats.total_size), false),
+            numbers.count(Some(self.dir_listing.stats.total_rentries), false)
         ))
         .fg(TEXT_FG_COLOR)
         .bold();
@@ -136,6 +145,8 @@ impl App {
     }
 
     fn columns(&self) -> Columns {
+        let numbers = Numbers::from_exact(self.exact);
+
         let widest = |f: &dyn Fn(&DirEntry) -> String| -> usize {
             self.dir_listing
                 .iter_entries()
@@ -155,9 +166,12 @@ impl App {
 
         Columns {
             gauge: GAUGE_WIDTH,
+            size: SIZE_WIDTH.max(widest(&|e| numbers.size(e.size, true))),
+            rentries: RENTRIES_WIDTH.max(widest(&|e| numbers.count(e.rentries, true))),
             user,
             group,
             ctime: if self.show_ctime { CTIME_FMT_WIDTH } else { 0 },
+            numbers,
             current_year: Local::now().year() as isize,
             show_owner: self.show_owner,
             show_ctime: self.show_ctime,
@@ -269,7 +283,11 @@ impl DirEntry {
         };
 
         spans.push(style_selected(Span::styled(
-            format!("{:>8} ┃", size_str(self.size, true)),
+            format!(
+                "{:>width$} ┃",
+                cols.numbers.size(self.size, true),
+                width = cols.size
+            ),
             text_color,
         )));
 
@@ -281,7 +299,11 @@ impl DirEntry {
         ));
 
         spans.push(style_selected(Span::styled(
-            format!("┃  {:>7} ┃", rentries_str(self.rentries, true)),
+            format!(
+                "┃  {:>width$} ┃",
+                cols.numbers.count(self.rentries, true),
+                width = cols.rentries
+            ),
             text_color,
         )));
 
@@ -684,6 +706,56 @@ mod tests {
             "'d' did not toggle back"
         );
         assert!(!shows_indicator(&mut app), "indicator outlived the mode");
+    }
+
+    #[test]
+    fn exact_key_switches_the_numbers() {
+        let mut app = app();
+        let text = |app: &mut App| frame(app).join("\n");
+
+        let units = text(&mut app);
+        assert!(units.contains("800.0 GB"), "{}", units);
+        assert!(units.contains("60.0 K"), "{}", units);
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('e')));
+        let exact = text(&mut app);
+        assert!(exact.contains("800000000000"), "{}", exact);
+        assert!(exact.contains("60000"), "{}", exact);
+        assert!(!exact.contains("800.0 GB"), "{}", exact);
+        // The totals in the title follow the same setting.
+        assert!(exact.contains("100000 files"), "{}", exact);
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('e')));
+        assert_eq!(text(&mut app), units, "'e' did not toggle back");
+    }
+
+    /// Exact values are wider than any unit form, so the column grows. The rest of
+    /// the row has to stay aligned and inside the frame when it does.
+    #[test]
+    fn exact_widens_its_column_without_raggedness() {
+        let mut app = app();
+        app.exact = true;
+        let lines = frame(&mut app);
+
+        // Character columns, not byte offsets: the gauges are three bytes per cell.
+        let name_columns: Vec<usize> = lines[3..7]
+            .iter()
+            .zip(["..", "a/", "b/", "c.dat"])
+            .map(|(line, name)| {
+                let byte = line.rfind(name).unwrap();
+                line[..byte].chars().count()
+            })
+            .collect();
+        assert!(
+            name_columns.windows(2).all(|w| w[0] == w[1]),
+            "ragged name column:\n{}",
+            lines.join("\n")
+        );
+
+        // Rows 2 onwards are the bordered block, which spans the full width.
+        for line in &lines[2..] {
+            assert_eq!(line.chars().count(), 80, "{:?} is not full width", line);
+        }
     }
 
     /// The status area lives in the bottom border and must not disturb the rest of it.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -425,3 +425,192 @@ pub fn ui(frame: &mut Frame, app: &mut App) {
         render_popup(popup, popup_areas, frame.buffer_mut());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{App, DEFAULT_SORT_MODE, DirListing, EntryKind};
+    use crossterm::event::{KeyCode, KeyEvent};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use std::path::PathBuf;
+
+    fn entries() -> Vec<DirEntry> {
+        let entry = |name: &str, kind, size, rentries| DirEntry {
+            name: name.to_string(),
+            kind,
+            size: Some(size),
+            rentries,
+            ctime: Some(992_606_400),
+            user: Some("alice".to_string()),
+            group: Some("scc".to_string()),
+        };
+        vec![
+            entry("a/", EntryKind::Dir, 800_000_000_000, Some(60_000)),
+            entry("b/", EntryKind::Dir, 200_000_000_000, Some(40_000)),
+            entry("c.dat", EntryKind::File, 1_000_000, None),
+        ]
+    }
+
+    /// An app whose listing is synthetic, so the frame doesn't depend on the
+    /// filesystem the tests happen to run on. The cwd is faked for the same reason;
+    /// App::new only needs a readable directory to start from.
+    fn app() -> App {
+        let mut app = App::new(Some(&PathBuf::from("."))).unwrap();
+        app.cwd = PathBuf::from("/ceph/users/alice");
+        app.dir_listing = DirListing::from_entries(entries(), true, DEFAULT_SORT_MODE);
+        app.message(None);
+        app
+    }
+
+    fn frame(app: &mut App) -> Vec<String> {
+        frame_sized(app, 80, 10)
+    }
+
+    fn frame_sized(app: &mut App, width: u16, height: u16) -> Vec<String> {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal.draw(|f| ui(f, app)).unwrap();
+        let buf = terminal.backend().buffer();
+        (0..buf.area.height)
+            .map(|y| {
+                (0..buf.area.width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect()
+    }
+
+    /// Everything below the header, which carries the version number.
+    const EXPECTED: &[&str] = &[
+        "",
+        "┏ /ceph/users/alice ━━ 1.0 TB, 100.0 K files ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓",
+        "┃>          ┃                    ┃          ┃                    ┃ ..          ┃",
+        "┃  800.0 GB ┃███████ 80.0%███████┃   60.0 K ┃███████ 60.0%███████┃ a/          ┃",
+        "┃  200.0 GB ┃█████   20.0%       ┃   40.0 K ┃███████ 40.0%▍      ┃ b/          ┃",
+        "┃    1.0 MB ┃         0.0%       ┃          ┃                    ┃ c.dat       ┃",
+        "┃                                                                              ┃",
+        "┃                                                                              ┃",
+        "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Press ? for help ┛",
+    ];
+
+    #[test]
+    fn renders_the_listing() {
+        let lines = frame(&mut app());
+
+        assert!(lines[0].contains("cephdu v"), "{:?}", lines[0]);
+        assert_eq!(&lines[1..], EXPECTED, "\n{}", lines.join("\n"));
+    }
+
+    /// The row the cursor is on is filled manually rather than by ratatui's
+    /// highlight style, so the fill is worth checking directly.
+    #[test]
+    fn highlights_the_selected_row() {
+        let mut app = app();
+        let mut terminal = Terminal::new(TestBackend::new(80, 10)).unwrap();
+        terminal.draw(|f| ui(f, &mut app)).unwrap();
+        let buf = terminal.backend().buffer();
+
+        // Row 2 is "..", the initial selection; row 3 is the first real entry.
+        assert_eq!(buf[(5, 3)].bg, SELECTED_BG_COLOR);
+        assert_eq!(buf[(5, 4)].bg, LIST_BG_COLOR);
+    }
+
+    #[test]
+    fn moving_the_cursor_moves_the_marker() {
+        let mut app = app();
+        assert!(frame(&mut app)[3].starts_with("┃>"));
+
+        app.handle_key(KeyEvent::from(KeyCode::Down));
+        let lines = frame(&mut app);
+        assert!(lines[3].starts_with("┃ "), "{:?}", lines[3]);
+        assert!(lines[4].starts_with("┃>"), "{:?}", lines[4]);
+        assert!(lines[4].contains("a/"), "{:?}", lines[4]);
+
+        // The cursor must stop at the top rather than wrapping.
+        app.handle_key(KeyEvent::from(KeyCode::Up));
+        app.handle_key(KeyEvent::from(KeyCode::Up));
+        assert!(frame(&mut app)[3].starts_with("┃>"));
+    }
+
+    /// Wide enough that both optional columns fit; at 80 columns the time column
+    /// is truncated once the owner column is also shown.
+    #[test]
+    fn owner_and_time_columns_are_toggled() {
+        let mut app = app();
+        let wide = |app: &mut App| frame_sized(app, 120, 10);
+
+        let hidden = wide(&mut app);
+        assert!(!hidden.iter().any(|l| l.contains("alice:scc")));
+        assert!(!hidden.iter().any(|l| l.contains("2001")));
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('u')));
+        assert!(
+            wide(&mut app).iter().any(|l| l.contains("alice:scc")),
+            "owner column did not appear"
+        );
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('t')));
+        let both = wide(&mut app);
+        assert!(
+            both.iter().any(|l| l.contains("2001")),
+            "time column did not appear:\n{}",
+            both.join("\n")
+        );
+        assert!(both.iter().any(|l| l.contains("alice:scc")));
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('u')));
+        app.handle_key(KeyEvent::from(KeyCode::Char('t')));
+        assert_eq!(wide(&mut app), hidden, "toggling back changed the frame");
+    }
+
+    #[test]
+    fn sorting_reorders_the_rows() {
+        let mut app = app();
+        // Rows 4..7 are the real entries; row 3 is "..".
+        let names = |app: &mut App| -> Vec<String> {
+            frame(app)[4..7]
+                .iter()
+                .map(|l| l.split('┃').nth(5).unwrap().trim().to_string())
+                .collect()
+        };
+
+        // Default is descending by size; pressing 's' again reverses it.
+        assert_eq!(names(&mut app), ["a/", "b/", "c.dat"]);
+        app.handle_key(KeyEvent::from(KeyCode::Char('s')));
+        assert_eq!(names(&mut app), ["c.dat", "b/", "a/"]);
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('n')));
+        assert_eq!(names(&mut app), ["a/", "b/", "c.dat"]);
+    }
+
+    #[test]
+    fn help_popup_lists_the_keys() {
+        let mut app = app();
+        app.handle_key(KeyEvent::from(KeyCode::Char('?')));
+
+        let lines = frame(&mut app);
+        let text = lines.join("\n");
+        assert!(text.contains("Help"), "{}", text);
+        assert!(text.contains("Quit"), "{}", text);
+        assert!(text.contains(env!("CARGO_PKG_REPOSITORY")), "{}", text);
+
+        app.handle_key(KeyEvent::from(KeyCode::Esc));
+        assert_eq!(frame(&mut app)[1..], *EXPECTED, "popup did not close");
+    }
+
+    /// A message replaces the blank line above the listing, and must not disturb it.
+    #[test]
+    fn messages_render_above_the_listing() {
+        let mut app = app();
+        app.message(Some(Message {
+            text: "Warning: not a Ceph directory".to_string(),
+            kind: MessageKind::Warning,
+        }));
+
+        let lines = frame(&mut app);
+        assert!(lines[1].contains("not a Ceph directory"), "{:?}", lines[1]);
+        assert_eq!(&lines[2..], &EXPECTED[1..], "\n{}", lines.join("\n"));
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -21,7 +21,18 @@ use crate::app::MessageKind;
 use crate::format::{CTIME_FMT_WIDTH, Numbers, ctime_str};
 use crate::popup::Popup;
 
-pub const POPUP_TEXT_HEIGHT: usize = 10;
+/// Rows of text the popup shows: as many as its text has, up to what the frame
+/// can hold. `CHROME` is what the popup costs besides text -- a border above and
+/// below it, two rows of footer -- plus a row of margin top and bottom, so it
+/// never sits edge to edge. `MIN` wins on a terminal too short for even that,
+/// where an unusable popup still beats none.
+fn popup_text_height(frame_height: u16, text_height: usize) -> usize {
+    const CHROME: u16 = 6;
+    const MIN: usize = 3;
+
+    let room = frame_height.saturating_sub(CHROME) as usize;
+    text_height.min(room).max(MIN)
+}
 
 const GAUGE_WIDTH: usize = 20;
 /// The colors the interface names, for their meaning rather than their shade.
@@ -239,8 +250,10 @@ impl App {
 
 fn render_popup(popup: &mut Popup, areas: [Rect; 2], buf: &mut Buffer) {
     let top_border_set = symbols::border::Set {
-        // Connect the top block with the bottom block
+        // Connect the top block with the bottom block. Both corners: without a
+        // scrollbar drawn over it, the right one is on show too.
         bottom_left: symbols::line::THICK.vertical_right,
+        bottom_right: symbols::line::THICK.vertical_left,
         ..symbols::border::THICK
     };
 
@@ -269,11 +282,15 @@ fn render_popup(popup: &mut Popup, areas: [Rect; 2], buf: &mut Buffer) {
     paragraph.render(areas[0], buf);
     footer.render(areas[1], buf);
 
-    Scrollbar::new(ScrollbarOrientation::VerticalRight).render(
-        areas[0],
-        buf,
-        &mut popup.scrollbar_state,
-    );
+    // Nothing to scroll when the text fits, which on a tall enough terminal is
+    // the usual case.
+    if popup.max_scroll() > 0 {
+        Scrollbar::new(ScrollbarOrientation::VerticalRight).render(
+            areas[0],
+            buf,
+            &mut popup.scrollbar_state,
+        );
+    }
 }
 
 /// Keep the end of a path when it is too long to show: the deepest components are
@@ -485,9 +502,13 @@ pub fn ui(frame: &mut Frame, app: &mut App) {
     app.render_message(&message, message_area, frame.buffer_mut());
 
     if let Some(popup) = &mut app.popup {
+        // Only the renderer knows the terminal's height, so this is where the
+        // popup learns how much of its text is on screen.
+        let text_height = popup_text_height(frame.area().height, popup.text_height);
+        popup.set_view_height(text_height);
         let popup_areas = popup_rects(
             popup.text_width as u16 + 4,
-            POPUP_TEXT_HEIGHT as u16 + 2,
+            text_height as u16 + 2,
             frame.area(),
         );
         render_popup(popup, popup_areas, frame.buffer_mut());
@@ -1095,6 +1116,69 @@ mod tests {
         assert!(border.contains("dirs first"), "{}", border);
         assert!(border.contains("Press ? for help"), "{}", border);
         assert_eq!(border.chars().count(), 80, "{}", border);
+    }
+
+    /// The popup shows as much of its text as the terminal has room for, so on a
+    /// tall one the help needs no scrolling at all.
+    #[test]
+    fn the_help_popup_grows_with_the_terminal() {
+        let rows_shown = |height: u16| -> usize {
+            let mut app = app();
+            app.handle_key(KeyEvent::from(KeyCode::Char('?')));
+            frame_sized(&mut app, 80, height)
+                .iter()
+                .filter(|line| line.contains(":  "))
+                .count()
+        };
+
+        assert!(
+            rows_shown(10) < rows_shown(24) && rows_shown(24) < rows_shown(40),
+            "the popup did not grow: {} rows at 10, {} at 24, {} at 40",
+            rows_shown(10),
+            rows_shown(24),
+            rows_shown(40)
+        );
+        assert_eq!(
+            rows_shown(40),
+            crate::navigation::HELP.len(),
+            "a terminal with room for every key should show every key"
+        );
+    }
+
+    /// The scrollbar is drawn only when something is off screen.
+    #[test]
+    fn the_help_popup_scrollbar_appears_only_when_it_must() {
+        let has_scrollbar = |height: u16| -> bool {
+            let mut app = app();
+            app.handle_key(KeyEvent::from(KeyCode::Char('?')));
+            frame_sized(&mut app, 80, height)
+                .iter()
+                .any(|line| line.contains('▲'))
+        };
+
+        assert!(has_scrollbar(10), "a clipped popup needs its scrollbar");
+        assert!(!has_scrollbar(40), "a popup that fits drew one anyway");
+    }
+
+    /// End goes to the last line. It used to scroll to the viewport height
+    /// instead, which falls short of the end whenever the text is more than twice
+    /// as tall as the view.
+    #[test]
+    fn end_reaches_the_bottom_of_the_help() {
+        let mut app = app();
+        app.handle_key(KeyEvent::from(KeyCode::Char('?')));
+        // Drawn once first, since a frame is where the popup learns its height.
+        frame_sized(&mut app, 80, 10);
+
+        app.handle_key(KeyEvent::from(KeyCode::End));
+        let text = frame_sized(&mut app, 80, 10).join("\n");
+        let last = crate::navigation::HELP.last().unwrap()[1];
+        assert!(
+            text.contains(last),
+            "End stopped short of {:?}:\n{}",
+            last,
+            text
+        );
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -45,6 +45,8 @@ const POPUP_BG_COLOR: Color = SLATE.c950;
 pub const POPUP_TEXT_HEIGHT: usize = 10;
 
 const GAUGE_WIDTH: usize = 20;
+/// Marks the selected row, and is prepended to every row by the list widget.
+const HIGHLIGHT_SYMBOL: &str = "> ";
 /// Minimum widths of the size and count columns. The unit forms never exceed these,
 /// so only exact values widen them.
 const SIZE_WIDTH: usize = 8;
@@ -134,14 +136,35 @@ impl App {
             })
             .collect();
 
-        // Create a List from all list items and highlight the currently selected one
+        // Rows can be wider than the terminal, and ratatui's List has no horizontal
+        // offset, so the rows are rendered to a buffer as wide as they need and a
+        // window of it is copied out. That scrolls every column alike, and leaves
+        // the block to draw the border and its titles in place.
+        let content_width = items
+            .iter()
+            .map(|item| item.width() + HIGHLIGHT_SYMBOL.len())
+            .max()
+            .unwrap_or(0);
+
+        let inner = block.inner(area);
+        block.render(area, buf);
+
         let list = List::new(items)
-            .block(block)
-            .highlight_symbol("> ")
+            .highlight_symbol(HIGHLIGHT_SYMBOL)
             .highlight_spacing(HighlightSpacing::Always)
             .bg(LIST_BG_COLOR);
 
-        StatefulWidget::render(list, area, buf, self.dir_listing.state_mut());
+        let width = content_width.max(inner.width as usize);
+        self.hscroll = self.hscroll.min(width - inner.width as usize);
+
+        let mut rows = Buffer::empty(Rect::new(0, 0, width as u16, inner.height));
+        StatefulWidget::render(list, rows.area, &mut rows, self.dir_listing.state_mut());
+
+        for y in 0..inner.height {
+            for x in 0..inner.width {
+                buf[(inner.x + x, inner.y + y)] = rows[((self.hscroll as u16) + x, y)].clone();
+            }
+        }
     }
 
     fn columns(&self) -> Columns {
@@ -756,6 +779,88 @@ mod tests {
         for line in &lines[2..] {
             assert_eq!(line.chars().count(), 80, "{:?} is not full width", line);
         }
+    }
+
+    /// A wide listing, so that there is something to scroll.
+    fn wide_app() -> App {
+        let mut app = app();
+        app.show_owner = true;
+        app.show_ctime = true;
+        app
+    }
+
+    /// The inside of a row, without the border cell at either end.
+    fn row_inside(app: &mut App, row: usize) -> Vec<char> {
+        let chars: Vec<char> = frame(app)[row].chars().collect();
+        chars[1..chars.len() - 1].to_vec()
+    }
+
+    /// The whole listing scrolls, every column alike; the border does not.
+    #[test]
+    fn scrolling_shifts_the_columns_not_the_border() {
+        let mut app = wide_app();
+
+        let before = frame(&mut app);
+        let row_before = row_inside(&mut app, 4);
+
+        app.handle_key(KeyEvent::from(KeyCode::Right));
+        app.handle_key(KeyEvent::from(KeyCode::Right));
+        assert_eq!(app.hscroll, 8);
+
+        let after = frame(&mut app);
+        let row_after = row_inside(&mut app, 4);
+
+        let shifted: Vec<char> = row_before.into_iter().skip(8).collect();
+        assert_eq!(
+            row_after[..shifted.len()],
+            shifted[..],
+            "the row did not shift by 8 columns"
+        );
+
+        // The border and its titles are drawn outside the scrolled window.
+        assert_eq!(before[2], after[2], "the top border moved");
+        assert_eq!(before[9], after[9], "the bottom border moved");
+    }
+
+    /// Rendering clamps the offset, because only the renderer knows how wide the
+    /// rows came out.
+    #[test]
+    fn scrolling_stops_at_the_right_edge() {
+        let mut app = wide_app();
+
+        app.hscroll = 10_000;
+        let clamped = frame(&mut app);
+        let max = app.hscroll;
+        assert!(max > 0 && max < 10_000, "offset was not clamped: {}", max);
+
+        app.handle_key(KeyEvent::from(KeyCode::Right));
+        assert_eq!(frame(&mut app), clamped, "scrolled past the end");
+        assert_eq!(app.hscroll, max);
+
+        app.handle_key(KeyEvent::from(KeyCode::Left));
+        assert_eq!(app.hscroll, max - 4);
+        assert_ne!(frame(&mut app), clamped);
+    }
+
+    #[test]
+    fn scrolling_stops_at_the_left_edge() {
+        let mut app = wide_app();
+        let home = frame(&mut app);
+
+        app.handle_key(KeyEvent::from(KeyCode::Left));
+        assert_eq!(app.hscroll, 0);
+        assert_eq!(frame(&mut app), home);
+    }
+
+    /// Rows that already fit have nothing to scroll.
+    #[test]
+    fn a_narrow_listing_does_not_scroll() {
+        let mut app = app();
+        let before = frame(&mut app);
+
+        app.handle_key(KeyEvent::from(KeyCode::Right));
+        assert_eq!(frame(&mut app), before, "scrolled a listing that fits");
+        assert_eq!(app.hscroll, 0);
     }
 
     /// The status area lives in the bottom border and must not disturb the rest of it.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -359,7 +359,7 @@ impl DirEntry {
             )));
         }
 
-        spans.push(Span::raw(format!(" {}", self.name)));
+        spans.push(Span::raw(format!(" {}", self.display_name())));
 
         let line = Line::from(spans);
         ListItem::new(line)
@@ -1040,6 +1040,27 @@ mod tests {
         assert_eq!(buf[(46, 5)].bg, Color::Reset);
         assert_eq!(buf[(52, 4)].bg, Color::Reset);
         assert_eq!(buf[(52, 5)].bg, Color::Reset);
+    }
+
+    /// The listing marks a symlink the way `ls -F` does.
+    #[test]
+    fn symlinks_are_marked_in_the_listing() {
+        let mut app = app();
+        app.dir_listing = DirListing::from_entries(
+            vec![
+                entry("link", EntryKind::Symlink, 8, None),
+                entry("plain", EntryKind::File, 9, None),
+            ],
+            true,
+            DEFAULT_SORT_MODE,
+            false,
+        );
+
+        let names: Vec<String> = frame(&mut app)[4..6]
+            .iter()
+            .map(|l| l.split('┃').nth(5).unwrap().trim().to_string())
+            .collect();
+        assert_eq!(names, ["plain", "link@"]);
     }
 
     /// The status area lives in the bottom border and must not disturb the rest of it.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -45,6 +45,17 @@ const POPUP_BG_COLOR: Color = SLATE.c950;
 pub const POPUP_TEXT_HEIGHT: usize = 10;
 
 const GAUGE_WIDTH: usize = 20;
+/// The widths and number formatting a frame's rows share. Measured once from the
+/// whole listing, since a column is only as narrow as its widest value.
+struct Columns {
+    gauge: usize,
+    user: usize,
+    group: usize,
+    ctime: usize,
+    current_year: isize,
+    show_owner: bool,
+    show_ctime: bool,
+}
 
 impl App {
     fn render_header(&self, area: Rect, buf: &mut Buffer) {
@@ -56,6 +67,8 @@ impl App {
     }
 
     fn render_list(&mut self, area: Rect, buf: &mut Buffer) {
+        let cols = self.columns();
+
         let title = Line::from(format!(
             " {} ━━ {}, {} files ",
             self.cwd.to_str().unwrap_or("[invalid UTF-8]"),
@@ -91,31 +104,7 @@ impl App {
             .title_bottom(helptitle.right_aligned())
             .border_set(border::THICK);
 
-        let (user_width, group_width) = if self.show_owner {
-            (
-                self.dir_listing
-                    .iter_entries()
-                    .filter_map(|e| e.user.as_ref())
-                    .map(|s| s.len())
-                    .max()
-                    .unwrap_or(0),
-                self.dir_listing
-                    .iter_entries()
-                    .filter_map(|e| e.group.as_ref())
-                    .map(|s| s.len())
-                    .max()
-                    .unwrap_or(0),
-            )
-        } else {
-            (0, 0)
-        };
-
-        let ctime_width = if self.show_ctime { CTIME_FMT_WIDTH } else { 0 };
-
-        // Iterate through all elements in the `items` and stylize them.
         let selected = self.dir_listing.selected();
-        // Get the current year so that we know how to format a time string
-        let current_year = Local::now().year() as isize;
         let items: Vec<ListItem> = self
             .dir_listing
             .iter_entries()
@@ -123,15 +112,9 @@ impl App {
             .map(|(i, entry)| {
                 entry
                     .to_listitem(
-                        GAUGE_WIDTH,
+                        &cols,
                         &self.dir_listing.stats,
-                        user_width,
-                        group_width,
-                        ctime_width,
-                        current_year,
                         selected.map(|s| s == i).unwrap_or(false),
-                        self.show_owner,
-                        self.show_ctime,
                     )
                     .fg(TEXT_FG_COLOR)
                     .bg(if selected.map(|s| s == i).unwrap_or(false) {
@@ -150,6 +133,35 @@ impl App {
             .bg(LIST_BG_COLOR);
 
         StatefulWidget::render(list, area, buf, self.dir_listing.state_mut());
+    }
+
+    fn columns(&self) -> Columns {
+        let widest = |f: &dyn Fn(&DirEntry) -> String| -> usize {
+            self.dir_listing
+                .iter_entries()
+                .map(|e| f(e).len())
+                .max()
+                .unwrap_or(0)
+        };
+
+        let (user, group) = if self.show_owner {
+            (
+                widest(&|e| e.user.clone().unwrap_or_default()),
+                widest(&|e| e.group.clone().unwrap_or_default()),
+            )
+        } else {
+            (0, 0)
+        };
+
+        Columns {
+            gauge: GAUGE_WIDTH,
+            user,
+            group,
+            ctime: if self.show_ctime { CTIME_FMT_WIDTH } else { 0 },
+            current_year: Local::now().year() as isize,
+            show_owner: self.show_owner,
+            show_ctime: self.show_ctime,
+        }
     }
 
     fn render_message(&self, message: &Option<Message>, area: Rect, buf: &mut Buffer) {
@@ -222,18 +234,11 @@ fn safe_div(a: usize, b: usize) -> f64 {
 }
 
 impl DirEntry {
-    #[allow(clippy::too_many_arguments)]
     fn to_listitem(
         &self,
-        gauge_width: usize,
+        cols: &Columns,
         listing_stats: &ListingStats,
-        user_width: usize,
-        group_width: usize,
-        ctime_width: usize,
-        current_year: isize,
         selected: bool,
-        show_owner: bool,
-        show_ctime: bool,
     ) -> ListItem<'static> {
         // The borrow checker complains that self.dir_listing remains borrowed
         // immutably unless we insist on the static lifetime of the ListItem.
@@ -271,45 +276,47 @@ impl DirEntry {
         spans.extend(gauge(
             size_gauge_fraction,
             size_gauge_percent,
-            gauge_width,
+            cols.gauge,
             selected,
         ));
 
         spans.push(style_selected(Span::styled(
-            format!("┃  {:>7} ┃", rentries_str(self.rentries, true),),
+            format!("┃  {:>7} ┃", rentries_str(self.rentries, true)),
             text_color,
         )));
 
         spans.extend(gauge(
             rentries_gauge_fraction,
             rentries_gauge_percent,
-            gauge_width,
+            cols.gauge,
             selected,
         ));
 
         spans.push(style_selected(Span::styled("┃", text_color)));
 
-        if show_owner {
+        if cols.show_owner {
             if let Some(user) = &self.user {
                 spans.push(style_selected(Span::styled(
-                    format!(" {:>uwidth$}", user, uwidth = user_width),
+                    format!(" {:>uwidth$}", user, uwidth = cols.user),
                     text_color,
                 )));
             }
             if let Some(group) = &self.group {
                 spans.push(style_selected(Span::styled(
-                    format!(":{:gwidth$}", group, gwidth = group_width),
+                    format!(":{:gwidth$}", group, gwidth = cols.group),
                     text_color,
                 )));
             }
         }
 
-        if show_ctime && let Some(ctime_seconds) = self.ctime {
+        if cols.show_ctime
+            && let Some(ctime_seconds) = self.ctime
+        {
             spans.push(style_selected(Span::styled(
                 format!(
                     " {:cwidth$}",
-                    ctime_str(ctime_seconds, current_year),
-                    cwidth = ctime_width
+                    ctime_str(ctime_seconds, cols.current_year),
+                    cwidth = cols.ctime
                 ),
                 text_color,
             )));

--- a/tests/ceph.rs
+++ b/tests/ceph.rs
@@ -130,7 +130,47 @@ fn empty_directory_counts_zero() {
     fs::remove_dir_all(&dir).unwrap();
 }
 
-/// Off Ceph these columns are blank; here they must carry real values.
+/// Creating a directory sets its ctime but never its rctime, which the MDS only
+/// fills in on the first rstat update. So a directory nothing has happened in since
+/// it was made reports zero, which renders as the epoch -- idiomatic for a Unix
+/// timestamp that was never set, and passed through rather than hidden.
+#[test]
+fn a_pristine_directory_reports_no_recursive_time() {
+    let Some(dir) = scratch("pristine") else {
+        eprintln!("SKIP a_pristine_directory_reports_no_recursive_time: no CephFS available");
+        return;
+    };
+
+    fs::create_dir(dir.join("pristine")).unwrap();
+    write(dir.join("touched/f"), 10);
+
+    let out = Command::new(BIN)
+        .args(["--parseable", "-l", dir.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(out.stdout).unwrap();
+
+    for line in stdout.lines() {
+        let f: Vec<&str> = line.split('\t').collect();
+        let (time, name) = (f[2], f[5]);
+        if name == "pristine/" {
+            assert_eq!(
+                time, "0",
+                "creation set an rctime after all, or zero was hidden: {}",
+                line
+            );
+        } else {
+            time.parse::<u64>()
+                .unwrap_or_else(|_| panic!("{} has no time: {}", name, line));
+        }
+    }
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+/// Off Ceph these columns are blank; here they must carry real values. The time is
+/// the exception: a directory's is a third of the xattr round trips, so it is read
+/// only when asked for.
 #[test]
 fn human_output_shows_directory_sizes() {
     let Some(dir) = scratch("human") else {
@@ -141,17 +181,23 @@ fn human_output_shows_directory_sizes() {
     write(dir.join("data/big"), 2_000_000);
     assert_listing_settles(&dir, &[("2000000", "1", "data/")]);
 
-    let out = Command::new(BIN)
-        .args(["--flat", dir.to_str().unwrap()])
-        .output()
-        .unwrap();
-    let stdout = String::from_utf8(out.stdout).unwrap();
-    assert!(stdout.contains("2.0 MB"), "{}", stdout);
-    assert!(
-        !stdout.contains('-'),
-        "a column was unavailable: {}",
-        stdout
-    );
+    let human = |args: &[&str]| -> String {
+        let out = Command::new(BIN)
+            .args(args)
+            .arg(dir.to_str().unwrap())
+            .output()
+            .unwrap();
+        String::from_utf8(out.stdout).unwrap()
+    };
+
+    let plain = human(&["--flat"]);
+    assert!(plain.contains("2.0 MB"), "{}", plain);
+    assert!(plain.contains("data/"), "{}", plain);
+
+    // -l reads the recursive time as well, so nothing is left unavailable.
+    let long = human(&["--flat", "-l"]);
+    assert!(long.contains("2.0 MB"), "{}", long);
+    assert!(!long.contains('-'), "a column was unavailable: {}", long);
 
     fs::remove_dir_all(&dir).unwrap();
 }

--- a/tests/ceph.rs
+++ b/tests/ceph.rs
@@ -1,0 +1,157 @@
+//! Tests of the CephFS-specific behavior: the recursive size and entry count that
+//! the xattrs report, which is the whole reason this tool exists.
+//!
+//! These need a real CephFS mount, so they are skipped when there isn't one. Set
+//! CEPHDU_TEST_DIR to choose where the scratch tree goes; otherwise
+//! /mnt/ceph/users/$USER is used if it exists.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+const BIN: &str = env!("CARGO_BIN_EXE_cephdu");
+
+/// The MDS updates recursive stats asynchronously, so a freshly written tree does
+/// not report its final rbytes/rentries immediately.
+const SETTLE_TIMEOUT: Duration = Duration::from_secs(20);
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+fn ceph_base() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("CEPHDU_TEST_DIR") {
+        let dir = PathBuf::from(dir);
+        assert!(dir.is_dir(), "CEPHDU_TEST_DIR={:?} is not a directory", dir);
+        return Some(dir);
+    }
+
+    let user = std::env::var("USER").ok()?;
+    let dir = PathBuf::from("/mnt/ceph/users").join(user);
+    dir.is_dir().then_some(dir)
+}
+
+/// Returns None when there is no CephFS to test against.
+fn scratch(tag: &str) -> Option<PathBuf> {
+    let dir = ceph_base()?.join(format!("cephdu-test-{}-{}", std::process::id(), tag));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    Some(dir)
+}
+
+fn write(path: PathBuf, size: usize) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, vec![0u8; size]).unwrap();
+}
+
+/// Rows of (size, rentries, name), in listed order.
+fn listing(dir: &Path) -> Vec<(String, String, String)> {
+    let out = Command::new(BIN)
+        .args(["--parseable", dir.to_str().unwrap()])
+        .output()
+        .expect("failed to run cephdu");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(out.status.success(), "cephdu failed: {}", stderr);
+    assert!(
+        !stderr.contains("not a Ceph directory"),
+        "{:?} is not on CephFS; set CEPHDU_TEST_DIR to a Ceph path",
+        dir
+    );
+
+    String::from_utf8(out.stdout)
+        .unwrap()
+        .lines()
+        .map(|line| {
+            let f: Vec<&str> = line.split('\t').collect();
+            (f[0].to_string(), f[1].to_string(), f[5].to_string())
+        })
+        .collect()
+}
+
+/// Poll until the listing matches, since recursive stats settle asynchronously.
+fn assert_listing_settles(dir: &Path, expected: &[(&str, &str, &str)]) {
+    let expected: Vec<(String, String, String)> = expected
+        .iter()
+        .map(|(s, r, n)| (s.to_string(), r.to_string(), n.to_string()))
+        .collect();
+
+    let deadline = std::time::Instant::now() + SETTLE_TIMEOUT;
+    let mut last = listing(dir);
+    while last != expected && std::time::Instant::now() < deadline {
+        std::thread::sleep(POLL_INTERVAL);
+        last = listing(dir);
+    }
+
+    assert_eq!(
+        last, expected,
+        "recursive stats did not settle within {:?}",
+        SETTLE_TIMEOUT
+    );
+}
+
+/// Directory sizes are recursive, and entry counts exclude the directory itself.
+#[test]
+fn recursive_sizes_and_counts() {
+    let Some(dir) = scratch("recursive") else {
+        eprintln!("SKIP recursive_sizes_and_counts: no CephFS available");
+        return;
+    };
+
+    // a/ holds 1000 + 2000 bytes directly and 3000 more in a subdirectory, so its
+    // recursive size is 6000 across 4 entries (f1, f2, inner, f3).
+    write(dir.join("a/f1"), 1000);
+    write(dir.join("a/f2"), 2000);
+    write(dir.join("a/inner/f3"), 3000);
+    write(dir.join("b/f4"), 4000);
+    write(dir.join("top"), 5000);
+
+    assert_listing_settles(
+        &dir,
+        &[
+            ("6000", "4", "a/"),
+            ("5000", "-", "top"),
+            ("4000", "1", "b/"),
+        ],
+    );
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+/// An empty directory reports itself as empty, not as containing itself.
+#[test]
+fn empty_directory_counts_zero() {
+    let Some(dir) = scratch("empty") else {
+        eprintln!("SKIP empty_directory_counts_zero: no CephFS available");
+        return;
+    };
+
+    fs::create_dir(dir.join("nothing")).unwrap();
+    assert_listing_settles(&dir, &[("0", "0", "nothing/")]);
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+/// Off Ceph these columns are blank; here they must carry real values.
+#[test]
+fn human_output_shows_directory_sizes() {
+    let Some(dir) = scratch("human") else {
+        eprintln!("SKIP human_output_shows_directory_sizes: no CephFS available");
+        return;
+    };
+
+    write(dir.join("data/big"), 2_000_000);
+    assert_listing_settles(&dir, &[("2000000", "1", "data/")]);
+
+    let out = Command::new(BIN)
+        .args(["--flat", dir.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("2.0 MB"), "{}", stdout);
+    assert!(
+        !stdout.contains('-'),
+        "a column was unavailable: {}",
+        stdout
+    );
+
+    fs::remove_dir_all(&dir).unwrap();
+}

--- a/tests/flat_cli.rs
+++ b/tests/flat_cli.rs
@@ -58,6 +58,20 @@ fn tree(tag: &str) -> PathBuf {
     dir
 }
 
+/// Names deliberately in the reverse of size order, so a name sort and a size sort
+/// cannot be mistaken for one another.
+fn sort_tree(tag: &str) -> PathBuf {
+    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join(tag);
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+
+    fs::write(dir.join("apple.bin"), vec![0u8; 1_000]).unwrap();
+    fs::write(dir.join("middle.bin"), vec![0u8; 2_000]).unwrap();
+    fs::write(dir.join("zebra.bin"), vec![0u8; 3_000]).unwrap();
+
+    dir
+}
+
 fn path_arg(dir: &Path) -> String {
     dir.to_str().unwrap().to_string()
 }
@@ -217,6 +231,112 @@ fn empty_directory_prints_nothing() {
     let out = run(&["--parseable", &path_arg(&dir)]);
     assert!(out.success, "{}", out.stderr);
     assert_eq!(out.stdout, "");
+}
+
+/// The sort flags apply to flat mode, in the same directions as the interface keys.
+#[test]
+fn sort_flags_choose_the_order() {
+    let dir = sort_tree("sort_order");
+    let path = path_arg(&dir);
+
+    let names = |flag: &str| -> Vec<String> {
+        let args: Vec<&str> = if flag.is_empty() {
+            vec!["-p", &path]
+        } else {
+            vec!["-p", flag, &path]
+        };
+        let out = run(&args);
+        assert!(out.success, "{:?}: {}", args, out.stderr);
+        out.stdout
+            .lines()
+            .map(|l| l.rsplit('\t').next().unwrap().to_string())
+            .collect()
+    };
+
+    let by_name = ["apple.bin", "middle.bin", "zebra.bin"];
+    let by_size = ["zebra.bin", "middle.bin", "apple.bin"];
+
+    assert_eq!(names(""), by_size, "the default is largest first");
+    assert_eq!(names("-n"), by_name);
+    assert_eq!(names("-s"), by_size);
+    assert_eq!(names("--name"), by_name);
+    assert_eq!(names("--size"), by_size);
+}
+
+/// Every flag is accepted in both output modes and lists the same entries. Off Ceph
+/// the counts and times all tie, so the orders they produce can't be told apart
+/// here; tests/ceph.rs covers the counts where they have values.
+#[test]
+fn every_sort_flag_is_accepted() {
+    let dir = sort_tree("sort_accepted");
+    let path = path_arg(&dir);
+
+    for flag in [
+        "-n", "-s", "-c", "-u", "-t", "--name", "--size", "--count", "--owner", "--time",
+    ] {
+        for mode in ["-p", "-f"] {
+            let out = run(&[mode, flag, &path]);
+            assert!(out.success, "{} {}: {}", mode, flag, out.stderr);
+
+            let mut listed: Vec<&str> = out
+                .stdout
+                .lines()
+                .map(|l| l.split_whitespace().last().unwrap())
+                .collect();
+            listed.sort_unstable();
+            assert_eq!(
+                listed,
+                ["apple.bin", "middle.bin", "zebra.bin"],
+                "{} {}",
+                mode,
+                flag
+            );
+        }
+    }
+}
+
+/// -r flips whichever order is in effect, and composes with the field flags rather
+/// than being one of them.
+#[test]
+fn reverse_flips_the_order() {
+    let dir = sort_tree("sort_reverse");
+    let path = path_arg(&dir);
+
+    let names = |args: &[&str]| -> Vec<String> {
+        let mut argv = vec!["-p"];
+        argv.extend_from_slice(args);
+        argv.push(&path);
+        let out = run(&argv);
+        assert!(out.success, "{:?}: {}", args, out.stderr);
+        out.stdout
+            .lines()
+            .map(|l| l.rsplit('\t').next().unwrap().to_string())
+            .collect()
+    };
+
+    let ascending = ["apple.bin", "middle.bin", "zebra.bin"];
+    let descending = ["zebra.bin", "middle.bin", "apple.bin"];
+
+    // Bare -r reverses the default, which is by size.
+    assert_eq!(names(&[]), descending);
+    assert_eq!(names(&["-r"]), ascending);
+    assert_eq!(names(&["-s", "-r"]), ascending);
+
+    // Names run the other way, so reversing them descends.
+    assert_eq!(names(&["-n"]), ascending);
+    assert_eq!(names(&["-n", "-r"]), descending);
+
+    assert_eq!(names(&["--name", "--reverse"]), descending);
+    assert_eq!(names(&["-nr"]), descending, "combined short form");
+}
+
+#[test]
+fn sort_flags_are_mutually_exclusive() {
+    let dir = sort_tree("sort_exclusive");
+    let out = run(&["-p", "-n", "-s", &path_arg(&dir)]);
+
+    assert!(!out.success, "two sort flags were accepted");
+    assert!(out.stdout.is_empty(), "printed a listing anyway");
 }
 
 #[test]

--- a/tests/flat_cli.rs
+++ b/tests/flat_cli.rs
@@ -330,6 +330,43 @@ fn reverse_flips_the_order() {
     assert_eq!(names(&["-nr"]), descending, "combined short form");
 }
 
+/// -d groups directories ahead of files whatever the direction. Off Ceph this is
+/// easy to see, because a directory reports no size and would otherwise sort last.
+#[test]
+fn dirs_first_groups_directories() {
+    let dir = tree("dirs_first");
+    let path = path_arg(&dir);
+
+    let names = |args: &[&str]| -> Vec<String> {
+        let mut argv = vec!["-p"];
+        argv.extend_from_slice(args);
+        argv.push(&path);
+        let out = run(&argv);
+        assert!(out.success, "{:?}: {}", args, out.stderr);
+        out.stdout
+            .lines()
+            .map(|l| l.rsplit('\t').next().unwrap().to_string())
+            .collect()
+    };
+
+    assert_eq!(names(&[]), ["big.bin", "mid.bin", "notes.txt", "sub/"]);
+    assert_eq!(names(&["-d"]), ["sub/", "big.bin", "mid.bin", "notes.txt"]);
+    assert_eq!(
+        names(&["--dirs-first"]),
+        ["sub/", "big.bin", "mid.bin", "notes.txt"]
+    );
+
+    // Reversing turns the files around but leaves the directory on top.
+    assert_eq!(
+        names(&["-d", "-r"]),
+        ["sub/", "notes.txt", "mid.bin", "big.bin"]
+    );
+    assert_eq!(
+        names(&["-d", "-n"]),
+        ["sub/", "big.bin", "mid.bin", "notes.txt"]
+    );
+}
+
 #[test]
 fn sort_flags_are_mutually_exclusive() {
     let dir = sort_tree("sort_exclusive");

--- a/tests/flat_cli.rs
+++ b/tests/flat_cli.rs
@@ -1,0 +1,229 @@
+//! End-to-end tests of flat mode, driving the real binary.
+//!
+//! These run on any filesystem. The recursive values only exist on CephFS, so the
+//! assertions here cover file sizes (which every filesystem reports) and treat
+//! directory columns as present-or-absent, keyed off the binary's own warning.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_cephdu");
+
+struct Output {
+    stdout: String,
+    stderr: String,
+    success: bool,
+}
+
+impl Output {
+    /// Whether the directory under test is on CephFS, according to the binary.
+    fn on_ceph(&self) -> bool {
+        !self.stderr.contains("not a Ceph directory")
+    }
+
+    fn rows(&self) -> Vec<Vec<&str>> {
+        self.stdout
+            .lines()
+            .map(|line| line.split('\t').collect())
+            .collect()
+    }
+}
+
+fn run(args: &[&str]) -> Output {
+    let out = Command::new(BIN)
+        .args(args)
+        .output()
+        .expect("failed to run cephdu");
+
+    Output {
+        stdout: String::from_utf8(out.stdout).expect("stdout is not UTF-8"),
+        stderr: String::from_utf8(out.stderr).expect("stderr is not UTF-8"),
+        success: out.status.success(),
+    }
+}
+
+/// A tree with distinct file sizes, so the size sort is a total order and the
+/// expected row order holds whether or not directory sizes are available.
+fn tree(tag: &str) -> PathBuf {
+    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join(tag);
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("sub")).unwrap();
+
+    fs::write(dir.join("big.bin"), vec![0u8; 1_500_000]).unwrap();
+    fs::write(dir.join("mid.bin"), vec![0u8; 2_500]).unwrap();
+    fs::write(dir.join("notes.txt"), vec![0u8; 120]).unwrap();
+    fs::write(dir.join("sub").join("inner"), vec![0u8; 7]).unwrap();
+
+    dir
+}
+
+fn path_arg(dir: &Path) -> String {
+    dir.to_str().unwrap().to_string()
+}
+
+#[test]
+fn parseable_rows_have_six_fields_and_stable_order() {
+    let dir = tree("raw_rows");
+    let out = run(&["--parseable", &path_arg(&dir)]);
+    assert!(out.success, "{}", out.stderr);
+
+    let rows = out.rows();
+    assert_eq!(rows.len(), 4, "unexpected listing:\n{}", out.stdout);
+    for row in &rows {
+        assert_eq!(row.len(), 6, "wrong field count in {:?}", row);
+    }
+
+    // Descending by size; the directory is smallest either way.
+    let names: Vec<&str> = rows.iter().map(|r| r[5]).collect();
+    assert_eq!(names, ["big.bin", "mid.bin", "notes.txt", "sub/"]);
+
+    // File sizes come from stat, so they are exact on any filesystem.
+    let sizes: Vec<&str> = rows[..3].iter().map(|r| r[0]).collect();
+    assert_eq!(sizes, ["1500000", "2500", "120"]);
+
+    // Files have no recursive entry count.
+    for row in &rows[..3] {
+        assert_eq!(row[1], "-");
+        row[2].parse::<u64>().expect("ctime is not a number");
+    }
+
+    for row in &rows {
+        assert!(!row[3].is_empty(), "empty user in {:?}", row);
+        assert!(!row[4].is_empty(), "empty group in {:?}", row);
+    }
+
+    if out.on_ceph() {
+        rows[3][0]
+            .parse::<u64>()
+            .expect("dir rbytes is not a number");
+        rows[3][1]
+            .parse::<u64>()
+            .expect("dir rentries is not a number");
+    } else {
+        assert_eq!(rows[3][0], "-", "dir size should be unavailable off Ceph");
+        assert_eq!(rows[3][1], "-", "dir count should be unavailable off Ceph");
+    }
+}
+
+/// The listing is this directory's contents, so "..' has no place in it.
+#[test]
+fn dotdot_is_not_listed() {
+    let dir = tree("dotdot");
+    for args in [
+        vec!["--parseable", &path_arg(&dir)],
+        vec!["--flat", &path_arg(&dir)],
+    ] {
+        let out = run(&args);
+        assert!(!out.stdout.contains(".."), "{:?} listed '..'", args);
+    }
+}
+
+/// A pipe can't display the interactive interface, so a flat listing is implied,
+/// in the parseable format because the reader is more often a program. The child's
+/// stdout is always a pipe here, so the bare invocation exercises it.
+#[test]
+fn piped_stdout_implies_parseable() {
+    let dir = tree("piped");
+    let implied = run(&[&path_arg(&dir)]);
+    let explicit = run(&["--parseable", &path_arg(&dir)]);
+
+    assert!(implied.success, "{}", implied.stderr);
+    assert_eq!(implied.stdout, explicit.stdout);
+    assert!(
+        !implied.stdout.contains('\x1b'),
+        "escape sequences leaked into a pipe"
+    );
+}
+
+/// The parseable format must not depend on the terminal, so a parser sees the same
+/// bytes no matter how it is invoked.
+#[test]
+fn the_two_formats_are_distinct() {
+    let dir = tree("formats");
+    let parseable = run(&["--parseable", &path_arg(&dir)]);
+    let human = run(&["--flat", &path_arg(&dir)]);
+
+    assert!(human.success, "{}", human.stderr);
+    assert!(parseable.stdout.contains("1500000"), "{}", parseable.stdout);
+    assert!(!parseable.stdout.contains("1.5 MB"), "{}", parseable.stdout);
+
+    assert!(human.stdout.contains("1.5 MB"), "{}", human.stdout);
+    assert!(!human.stdout.contains("1500000"), "{}", human.stdout);
+    assert!(!human.stdout.contains('\t'), "human output has tabs");
+}
+
+/// The short and long forms mean the same thing, and -f alone means units.
+#[test]
+fn flag_spellings_agree() {
+    let dir = tree("spellings");
+    let path = path_arg(&dir);
+
+    let parseable = run(&["--parseable", &path]);
+    assert!(parseable.success, "{}", parseable.stderr);
+    assert_eq!(run(&["-p", &path]).stdout, parseable.stdout);
+
+    let human = run(&["-f", &path]);
+    assert_eq!(human.stdout, run(&["--flat", &path]).stdout);
+    assert!(human.stdout.contains("1.5 MB"), "{}", human.stdout);
+}
+
+#[test]
+fn human_rows_are_aligned() {
+    let dir = tree("aligned");
+    let out = run(&["--flat", &path_arg(&dir)]);
+
+    let name_columns: Vec<usize> = out
+        .stdout
+        .lines()
+        .zip(["big.bin", "mid.bin", "notes.txt", "sub/"])
+        .map(|(line, name)| line.rfind(name).unwrap())
+        .collect();
+    assert!(
+        name_columns.windows(2).all(|w| w[0] == w[1]),
+        "ragged name column:\n{}",
+        out.stdout
+    );
+}
+
+/// A script needs to see a failure, not a listing of somewhere else. This is the
+/// one place flat mode deliberately differs from the interactive interface, which
+/// falls back to the current directory.
+#[test]
+fn missing_path_is_an_error() {
+    let dir = tree("missing").join("no-such-dir");
+    let out = run(&["--parseable", &path_arg(&dir)]);
+
+    assert!(!out.success, "exited successfully on a missing path");
+    assert!(out.stdout.is_empty(), "printed a listing anyway");
+    assert!(out.stderr.contains("no-such-dir"), "{}", out.stderr);
+}
+
+#[test]
+fn a_file_argument_is_an_error() {
+    let dir = tree("notadir");
+    let out = run(&["--parseable", &path_arg(&dir.join("notes.txt"))]);
+
+    assert!(!out.success, "exited successfully on a file");
+    assert!(out.stdout.is_empty(), "printed a listing anyway");
+}
+
+#[test]
+fn empty_directory_prints_nothing() {
+    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("empty");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+
+    let out = run(&["--parseable", &path_arg(&dir)]);
+    assert!(out.success, "{}", out.stderr);
+    assert_eq!(out.stdout, "");
+}
+
+#[test]
+fn tui_conflicts_with_flat_flags() {
+    let dir = tree("conflict");
+    for flag in ["--flat", "--parseable"] {
+        let out = run(&["--tui", flag, &path_arg(&dir)]);
+        assert!(!out.success, "--tui {} was accepted", flag);
+    }
+}

--- a/tests/flat_cli.rs
+++ b/tests/flat_cli.rs
@@ -31,10 +31,22 @@ impl Output {
 }
 
 fn run(args: &[&str]) -> Output {
-    let out = Command::new(BIN)
-        .args(args)
-        .output()
-        .expect("failed to run cephdu");
+    run_from(None, &[], args)
+}
+
+/// Like `run`, from a given working directory and with environment overrides.
+/// Every invocation scrubs CEPHDU_DEFAULT_DIR first, so a shell that happens to
+/// set it can't leak a default directory into tests that assume none.
+fn run_from(cwd: Option<&Path>, env: &[(&str, &str)], args: &[&str]) -> Output {
+    let mut cmd = Command::new(BIN);
+    cmd.env_remove("CEPHDU_DEFAULT_DIR").args(args);
+    if let Some(cwd) = cwd {
+        cmd.current_dir(cwd);
+    }
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+    let out = cmd.output().expect("failed to run cephdu");
 
     Output {
         stdout: String::from_utf8(out.stdout).expect("stdout is not UTF-8"),
@@ -629,4 +641,69 @@ fn the_jobs_flag_is_hidden_from_help() {
     let dir = tree("jobs_hidden");
     let out = run(&["-p", "-j", "2", &path_arg(&dir)]);
     assert!(out.success, "{}", out.stderr);
+}
+
+/// An empty directory to run from, for the default-directory tests. Returns None
+/// (skip) when it lands on Ceph, where the cwd rightly wins over any default.
+fn non_ceph_cwd(tag: &str) -> Option<PathBuf> {
+    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join(tag);
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+
+    let probe = run_from(Some(&dir), &[], &["-p", "."]);
+    if probe.on_ceph() {
+        eprintln!("SKIP: {} is on Ceph, so the cwd wins over any default", tag);
+        return None;
+    }
+    Some(dir)
+}
+
+/// CEPHDU_DEFAULT_DIR names the starting directory when no PATH is given and the
+/// cwd is not on Ceph. An explicit PATH still wins, and an empty value means no
+/// default at all rather than falling back to one baked in at build time.
+#[test]
+fn the_default_dir_env_var_names_the_starting_directory() {
+    let target = tree("default_dir_target");
+    let Some(cwd) = non_ceph_cwd("default_dir_cwd") else {
+        return;
+    };
+    let env = [("CEPHDU_DEFAULT_DIR", target.to_str().unwrap())];
+
+    let out = run_from(Some(&cwd), &env, &["-p"]);
+    assert!(out.success, "{}", out.stderr);
+    assert!(out.stdout.contains("big.bin"), "{}", out.stdout);
+
+    let explicit = run_from(Some(&cwd), &env, &["-p", "."]);
+    assert!(explicit.success, "{}", explicit.stderr);
+    assert_eq!(explicit.stdout, "", "a PATH argument lost to the default");
+
+    let disabled = run_from(Some(&cwd), &[("CEPHDU_DEFAULT_DIR", "")], &["-p"]);
+    assert!(disabled.success, "{}", disabled.stderr);
+    assert_eq!(
+        disabled.stdout, "",
+        "an empty default was not treated as none"
+    );
+}
+
+/// A literal $USER in the variable expands to the current username, the same
+/// substitution the baked-in default gets.
+#[test]
+fn the_default_dir_env_var_expands_user() {
+    let Ok(username) = std::env::var("USER") else {
+        eprintln!("SKIP: USER is not set");
+        return;
+    };
+    let Some(cwd) = non_ceph_cwd("default_dir_user_cwd") else {
+        return;
+    };
+
+    let base = Path::new(env!("CARGO_TARGET_TMPDIR")).join("default_dir_user");
+    let _ = fs::remove_dir_all(&base);
+    fs::create_dir_all(base.join(&username)).unwrap();
+    fs::write(base.join(&username).join("marker.bin"), vec![0u8; 9]).unwrap();
+
+    let value = format!("{}/$USER", base.to_str().unwrap());
+    let out = run_from(Some(&cwd), &[("CEPHDU_DEFAULT_DIR", &value)], &["-p"]);
+    assert!(out.success, "{}", out.stderr);
+    assert!(out.stdout.contains("marker.bin"), "{}", out.stdout);
 }

--- a/tests/flat_cli.rs
+++ b/tests/flat_cli.rs
@@ -572,3 +572,47 @@ fn tui_conflicts_with_flat_flags() {
         assert!(!out.success, "--tui {} was accepted", flag);
     }
 }
+
+/// Concurrent reads are a speed choice, never an output one: whatever the jobs
+/// count, byte-identical listings, in both formats and with the extras read.
+#[test]
+fn concurrency_does_not_change_the_output() {
+    let dir = tree("jobs");
+    let path = path_arg(&dir);
+
+    for args in [
+        vec!["-p", &path],
+        vec!["-p", "-l", &path],
+        vec!["-f", "-n", &path],
+    ] {
+        let sequential = run(&args);
+        let concurrent = run(&[&args[..], &["-j", "5"]].concat());
+        assert!(concurrent.success, "{}", concurrent.stderr);
+        assert_eq!(
+            sequential.stdout, concurrent.stdout,
+            "-j changed the output of {:?}",
+            args
+        );
+    }
+}
+
+/// -j is deliberately undocumented: it may change or vanish, so neither help
+/// text may mention it. (The README is on the honor system.)
+#[test]
+fn the_jobs_flag_is_hidden_from_help() {
+    for flag in ["-h", "--help"] {
+        let out = run(&[flag]);
+        assert!(out.success);
+        assert!(
+            !out.stdout.contains("-j") && !out.stdout.contains("jobs"),
+            "{} mentions -j:\n{}",
+            flag,
+            out.stdout
+        );
+    }
+
+    // Hidden, not gone.
+    let dir = tree("jobs_hidden");
+    let out = run(&["-p", "-j", "2", &path_arg(&dir)]);
+    assert!(out.success, "{}", out.stderr);
+}

--- a/tests/flat_cli.rs
+++ b/tests/flat_cli.rs
@@ -487,10 +487,87 @@ fn symlinks_are_marked_in_the_human_format_only() {
     );
 }
 
+/// The owner costs a stat for every directory and a name lookup for every distinct
+/// owner, so it is read only when asked for.
+#[test]
+fn the_owner_is_read_only_with_the_flag() {
+    let dir = tree("owner");
+    let path = path_arg(&dir);
+
+    let plain = run(&["-p", &path]);
+    assert!(plain.success, "{}", plain.stderr);
+    for row in plain.rows() {
+        assert_eq!(row[3], "-", "an owner was read without -l: {:?}", row);
+        assert_eq!(row[4], "-", "a group was read without -l: {:?}", row);
+    }
+
+    let long = run(&["-p", "-l", &path]);
+    assert!(long.success, "{}", long.stderr);
+    for row in long.rows() {
+        assert_ne!(row[3], "-", "-l did not read the owner: {:?}", row);
+        assert_ne!(row[4], "-", "-l did not read the group: {:?}", row);
+    }
+    assert_eq!(
+        long.stdout,
+        run(&["-p", "--long", &path]).stdout,
+        "long forms disagree"
+    );
+
+    // -l implies --flat: into a pipe, where the default is parseable, it still gives
+    // the human format.
+    assert_eq!(
+        run(&["-l", &path]).stdout,
+        run(&["-f", "-l", &path]).stdout,
+        "-l did not imply --flat"
+    );
+    assert!(
+        !run(&["-l", &path]).stdout.contains('\t'),
+        "-l gave the parseable format"
+    );
+
+    // The human format drops the column rather than filling it with placeholders.
+    let human = run(&["-f", &path]);
+    let human_long = run(&["-f", "-l", &path]);
+    let first = |o: &Output| o.stdout.lines().next().unwrap().len();
+    assert!(
+        first(&human) < first(&human_long),
+        "the column was not dropped:\n{}",
+        human.stdout
+    );
+    // Not a bare ':' check: a ctime in the current year contains one.
+    let owner = long.rows()[0][3].to_string();
+    assert!(
+        !human.stdout.contains(&owner),
+        "{} appeared without -l:\n{}",
+        owner,
+        human.stdout
+    );
+    assert!(human_long.stdout.contains(&owner), "{}", human_long.stdout);
+}
+
+/// A file's time comes from the stat it needs anyway, so it is there either way. A
+/// directory's is an xattr round trip, and tests/ceph.rs covers it where there is one
+/// to find.
+#[test]
+fn a_file_keeps_its_time_without_the_flag() {
+    let dir = tree("times");
+    let path = path_arg(&dir);
+
+    for args in [vec!["-p", &path], vec!["-p", "-l", &path]] {
+        let out = run(&args);
+        assert!(out.success, "{}", out.stderr);
+        for row in out.rows().iter().filter(|r| !r[5].ends_with('/')) {
+            row[2]
+                .parse::<u64>()
+                .unwrap_or_else(|_| panic!("{:?}: file has no time in {:?}", args, row));
+        }
+    }
+}
+
 #[test]
 fn tui_conflicts_with_flat_flags() {
     let dir = tree("conflict");
-    for flag in ["--flat", "--parseable"] {
+    for flag in ["--flat", "--parseable", "--long"] {
         let out = run(&["--tui", flag, &path_arg(&dir)]);
         assert!(!out.success, "--tui {} was accepted", flag);
     }

--- a/tests/flat_cli.rs
+++ b/tests/flat_cli.rs
@@ -182,6 +182,51 @@ fn flag_spellings_agree() {
     assert!(human.stdout.contains("1.5 MB"), "{}", human.stdout);
 }
 
+/// -e prints values in full. The parseable format is already exact, so it has
+/// nothing to switch there.
+#[test]
+fn exact_shows_values_in_full() {
+    let dir = tree("exact");
+    let path = path_arg(&dir);
+
+    let units = run(&["-f", &path]);
+    let exact = run(&["-f", "-e", &path]);
+    assert!(exact.success, "{}", exact.stderr);
+
+    assert!(units.stdout.contains("1.5 MB"), "{}", units.stdout);
+    assert!(!units.stdout.contains("1500000"), "{}", units.stdout);
+
+    assert!(exact.stdout.contains("1500000"), "{}", exact.stdout);
+    assert!(!exact.stdout.contains("1.5 MB"), "{}", exact.stdout);
+    assert!(
+        !exact.stdout.contains('\t'),
+        "fell back to the parseable format"
+    );
+
+    assert_eq!(
+        exact.stdout,
+        run(&["--flat", "--exact", &path]).stdout,
+        "long forms disagree"
+    );
+    assert_eq!(
+        run(&["-p", "-e", &path]).stdout,
+        run(&["-p", &path]).stdout,
+        "-e changed the parseable format, which is already exact"
+    );
+
+    let name_columns: Vec<usize> = exact
+        .stdout
+        .lines()
+        .zip(["big.bin", "mid.bin", "notes.txt", "sub/"])
+        .map(|(line, name)| line.rfind(name).unwrap())
+        .collect();
+    assert!(
+        name_columns.windows(2).all(|w| w[0] == w[1]),
+        "ragged name column:\n{}",
+        exact.stdout
+    );
+}
+
 #[test]
 fn human_rows_are_aligned() {
     let dir = tree("aligned");

--- a/tests/flat_cli.rs
+++ b/tests/flat_cli.rs
@@ -72,6 +72,23 @@ fn sort_tree(tag: &str) -> PathBuf {
     dir
 }
 
+/// A symlink to a file, one to a directory, a broken one, and -- the case that rules
+/// out marking names in the parseable stream -- a symlink whose own name contains @.
+fn link_tree(tag: &str) -> PathBuf {
+    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join(tag);
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("realdir")).unwrap();
+    fs::write(dir.join("realfile"), vec![0u8; 5_000]).unwrap();
+
+    let link = std::os::unix::fs::symlink;
+    link("realfile", dir.join("link-to-file")).unwrap();
+    link("realdir", dir.join("link-to-dir")).unwrap();
+    link("/nonexistent/target", dir.join("broken-link")).unwrap();
+    link("realfile", dir.join("weird@name")).unwrap();
+
+    dir
+}
+
 fn path_arg(dir: &Path) -> String {
     dir.to_str().unwrap().to_string()
 }
@@ -419,6 +436,55 @@ fn sort_flags_are_mutually_exclusive() {
 
     assert!(!out.success, "two sort flags were accepted");
     assert!(out.stdout.is_empty(), "printed a listing anyway");
+}
+
+/// Symlinks are marked for a person and left alone for a parser.
+#[test]
+fn symlinks_are_marked_in_the_human_format_only() {
+    let dir = link_tree("links");
+    let path = path_arg(&dir);
+
+    let human = run(&["-f", &path]);
+    assert!(human.success, "{}", human.stderr);
+    for name in [
+        "link-to-file@",
+        "link-to-dir@",
+        "broken-link@",
+        "weird@name@",
+    ] {
+        assert!(
+            human.stdout.contains(name),
+            "{} missing:\n{}",
+            name,
+            human.stdout
+        );
+    }
+    // Regular entries keep their names, and directories their slash. The name ends
+    // the line, so an unmarked one is followed by the newline.
+    assert!(human.stdout.contains("realfile\n"), "{}", human.stdout);
+    assert!(human.stdout.contains("realdir/"), "{}", human.stdout);
+    assert!(!human.stdout.contains("realfile@"), "{}", human.stdout);
+
+    let parseable = run(&["-p", &path]);
+    let names: Vec<&str> = parseable
+        .stdout
+        .lines()
+        .map(|l| l.rsplit('\t').next().unwrap())
+        .collect();
+    let mut sorted = names.clone();
+    sorted.sort_unstable();
+    assert_eq!(
+        sorted,
+        [
+            "broken-link",
+            "link-to-dir",
+            "link-to-file",
+            "realdir/",
+            "realfile",
+            "weird@name",
+        ],
+        "the parseable stream marked a name"
+    );
 }
 
 #[test]

--- a/tests/flat_cli.rs
+++ b/tests/flat_cli.rs
@@ -573,6 +573,20 @@ fn tui_conflicts_with_flat_flags() {
     }
 }
 
+/// The info panel belongs to the interactive interface; the flat formats have
+/// no place for it and must not grow one, so the flag refuses to combine.
+#[test]
+fn info_conflicts_with_flat_flags() {
+    let dir = tree("info_conflict");
+    for flag in ["--flat", "--parseable", "--long"] {
+        let out = run(&["--info", flag, &path_arg(&dir)]);
+        assert!(!out.success, "--info {} was accepted", flag);
+    }
+
+    let out = run(&["-i", "-f", &path_arg(&dir)]);
+    assert!(!out.success, "-if was accepted");
+}
+
 /// Concurrent reads are a speed choice, never an output one: whatever the jobs
 /// count, byte-identical listings, in both formats and with the extras read.
 #[test]

--- a/tests/syscalls.rs
+++ b/tests/syscalls.rs
@@ -184,6 +184,52 @@ fn a_listing_costs_one_stat_per_file_and_two_xattrs_per_dir() {
     }
 }
 
+/// Concurrent reads (the hidden -j) must issue the same metadata syscalls per
+/// entry as reading one at a time -- only their timing changes. Only statx and
+/// lgetxattr are pinned here: thread plumbing (futex and friends) scales with
+/// the work, so the strict nothing-else-scales assertion belongs to the
+/// sequential path above.
+#[test]
+fn concurrency_adds_no_metadata_syscalls() {
+    if !strace_works() {
+        eprintln!("SKIP: strace unavailable or ptrace not permitted");
+        return;
+    }
+
+    const FILES: u64 = 100;
+    const DIRS: u64 = 20;
+
+    let base = tree("syscalls_j_base", 10, 2);
+    let more_files = tree("syscalls_j_files", 10 + FILES as usize, 2);
+    let more_dirs = tree("syscalls_j_dirs", 10, 2 + DIRS as usize);
+
+    let flags = &["-j", "4"];
+    let base = counts(&base, flags);
+    let files = slope(&base, &counts(&more_files, flags), FILES);
+    let dirs = slope(&base, &counts(&more_dirs, flags), DIRS);
+    report("added files [-j 4]", &files, FILES);
+    report("added dirs [-j 4]", &dirs, DIRS);
+
+    for (what, measured, name, want) in [
+        ("file", &files, "statx", 1),
+        ("file", &files, "lgetxattr", 0),
+        ("dir", &dirs, "statx", 0),
+        ("dir", &dirs, "lgetxattr", 2),
+    ] {
+        let (delta, _) = measured.get(name).copied().unwrap_or((0, 0.0));
+        let added = if what == "file" { FILES } else { DIRS };
+        assert_eq!(
+            delta,
+            want * added as i64,
+            "with -j 4, each {} costs {} {} calls, expected {}",
+            what,
+            delta as f64 / added as f64,
+            name,
+            want
+        );
+    }
+}
+
 /// readdir is batched, so it must not cost a syscall per entry either. Counted
 /// separately because the batch size is the kernel's business, not ours.
 #[test]

--- a/tests/syscalls.rs
+++ b/tests/syscalls.rs
@@ -1,0 +1,222 @@
+//! Counts the syscalls a listing costs, so that #7 can be reasoned about with
+//! numbers rather than guesses.
+//!
+//! The measurement is a *slope*, not a total: two trees differing by a known number
+//! of entries are traced and the counts subtracted, which cancels the fixed cost of
+//! starting a process (loading libc, resolving a uid, opening /dev/tty) and leaves
+//! only what each added entry costs. That is the part that matters for a directory
+//! with a million files in it, and unlike a total it doesn't move with the libc or
+//! kernel underneath.
+//!
+//! Needs strace and permission to ptrace, so it skips when either is missing.
+//!
+//! What this does *not* cover: `ls()` polls for Ctrl-C once per entry, and crossterm
+//! only issues a syscall for that when its event source initialises, which needs a
+//! controlling terminal. Under a test runner /dev/tty fails to open with ENXIO, so
+//! the poll is free here and the interface may well pay one more syscall per entry
+//! than these numbers show. Measuring it needs a real terminal:
+//!
+//!     strace -f -c -o /tmp/tui.trace cephdu --tui <dir>   # then press q
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_cephdu");
+
+type Counts = BTreeMap<String, u64>;
+
+fn strace_works() -> bool {
+    let out = Command::new("strace")
+        .args(["-c", "-o", "/dev/null", "true"])
+        .output();
+    matches!(out, Ok(out) if out.status.success())
+}
+
+fn tree(tag: &str, files: usize, dirs: usize) -> PathBuf {
+    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join(tag);
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+
+    for i in 0..files {
+        fs::write(dir.join(format!("file{}", i)), b"0123456789").unwrap();
+    }
+    for i in 0..dirs {
+        fs::create_dir(dir.join(format!("dir{}", i))).unwrap();
+    }
+    dir
+}
+
+/// Syscall name to number of calls, from `strace -c`.
+fn counts(dir: &Path, extra: &[&str]) -> Counts {
+    let summary = Path::new(env!("CARGO_TARGET_TMPDIR")).join(format!(
+        "strace-{}{}.txt",
+        dir.file_name().unwrap().to_str().unwrap(),
+        extra.concat()
+    ));
+
+    let out = Command::new("strace")
+        .arg("-f")
+        .arg("-c")
+        .arg("-o")
+        .arg(&summary)
+        .arg(BIN)
+        // The parseable listing is the deterministic path, and it exercises the same
+        // ls() that the interface uses.
+        .args(["-p", dir.to_str().unwrap()])
+        .args(extra)
+        .output()
+        .expect("failed to run strace");
+    assert!(
+        out.status.success(),
+        "cephdu under strace failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let text = fs::read_to_string(&summary).unwrap();
+    let mut counts = Counts::new();
+    for line in text.lines() {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        // "% time seconds usecs/call calls [errors] syscall", plus a total line.
+        if fields.len() < 5 || fields[0].parse::<f64>().is_err() {
+            continue;
+        }
+        let name = *fields.last().unwrap();
+        if name == "total" {
+            continue;
+        }
+        if let Ok(calls) = fields[3].parse::<u64>() {
+            *counts.entry(name.to_string()).or_default() += calls;
+        }
+    }
+    assert!(!counts.is_empty(), "no syscalls parsed from {:?}", summary);
+    counts
+}
+
+/// What each of the `added` extra entries cost, as whole calls. Fractional slopes
+/// would mean the cost isn't per-entry at all, so they are reported rather than
+/// rounded away.
+fn slope(base: &Counts, bigger: &Counts, added: u64) -> BTreeMap<String, (i64, f64)> {
+    let mut out = BTreeMap::new();
+    for name in base.keys().chain(bigger.keys()) {
+        let delta = *bigger.get(name).unwrap_or(&0) as i64 - *base.get(name).unwrap_or(&0) as i64;
+        if delta != 0 {
+            out.insert(name.clone(), (delta, delta as f64 / added as f64));
+        }
+    }
+    out
+}
+
+fn report(what: &str, slope: &BTreeMap<String, (i64, f64)>, added: u64) {
+    println!("\n{} ({} added):", what, added);
+    println!("  {:<14} {:>8} {:>10}", "syscall", "delta", "per entry");
+    for (name, (delta, per)) in slope {
+        println!("  {:<14} {:>8} {:>10.2}", name, delta, per);
+    }
+}
+
+/// The cost model of a listing, one syscall at a time. A file costs a stat, for its
+/// size and time. A directory costs two xattrs -- its size and its count -- and no
+/// stat at all: its kind comes from readdir, its owner is not read, and neither is
+/// its recursive time, which was a third of the round trips. Nothing else may scale
+/// with the number of entries; that is the assertion worth having, because an
+/// accidental per-entry syscall is exactly what makes a large directory slow.
+#[test]
+fn a_listing_costs_one_stat_per_file_and_two_xattrs_per_dir() {
+    if !strace_works() {
+        eprintln!("SKIP: strace unavailable or ptrace not permitted");
+        return;
+    }
+
+    const FILES: u64 = 100;
+    const DIRS: u64 = 20;
+
+    let base = tree("syscalls_base", 10, 2);
+    let more_files = tree("syscalls_files", 10 + FILES as usize, 2);
+    let more_dirs = tree("syscalls_dirs", 10, 2 + DIRS as usize);
+
+    // Without the extras, and then with them: -l is what puts the stat back on a
+    // directory and asks for the third xattr.
+    for (flags, per_file, per_dir) in [
+        (
+            &[][..],
+            [("statx", 1)].as_slice(),
+            [("lgetxattr", 2)].as_slice(),
+        ),
+        (
+            &["-l"][..],
+            [("statx", 1)].as_slice(),
+            [("statx", 1), ("lgetxattr", 3)].as_slice(),
+        ),
+    ] {
+        let base = counts(&base, flags);
+        let files = slope(&base, &counts(&more_files, flags), FILES);
+        let dirs = slope(&base, &counts(&more_dirs, flags), DIRS);
+        report(&format!("added files {:?}", flags), &files, FILES);
+        report(&format!("added dirs {:?}", flags), &dirs, DIRS);
+
+        for (what, measured, expected, added) in [
+            ("file", &files, per_file, FILES),
+            ("dir", &dirs, per_dir, DIRS),
+        ] {
+            let expected: BTreeMap<&str, i64> = expected.iter().copied().collect();
+            for (name, (delta, _)) in measured {
+                let want = expected.get(name.as_str()).copied().unwrap_or(0);
+                assert_eq!(
+                    *delta,
+                    want * added as i64,
+                    "with {:?}, each {} costs {} {} calls, expected {}",
+                    flags,
+                    what,
+                    *delta as f64 / added as f64,
+                    name,
+                    want
+                );
+            }
+            for (name, want) in &expected {
+                assert!(
+                    measured.contains_key(*name),
+                    "with {:?}, no {} calls scale with the number of {}s; expected {} each",
+                    flags,
+                    name,
+                    what,
+                    want
+                );
+            }
+        }
+    }
+}
+
+/// readdir is batched, so it must not cost a syscall per entry either. Counted
+/// separately because the batch size is the kernel's business, not ours.
+#[test]
+fn readdir_is_batched() {
+    if !strace_works() {
+        eprintln!("SKIP: strace unavailable or ptrace not permitted");
+        return;
+    }
+
+    let small = counts(&tree("getdents_small", 10, 0), &[]);
+    let large = counts(&tree("getdents_large", 1010, 0), &[]);
+
+    let batches = |c: &Counts| *c.get("getdents64").unwrap_or(&0);
+    let total = |c: &Counts| c.values().sum::<u64>();
+    println!(
+        "\ngetdents64: {} for 10 entries, {} for 1010",
+        batches(&small),
+        batches(&large)
+    );
+    println!(
+        "a 1010-entry listing costs {} syscalls in total, {:.2} per entry",
+        total(&large),
+        total(&large) as f64 / 1010.0
+    );
+
+    // A thousand more entries must not cost a thousand more calls.
+    assert!(
+        batches(&large) < 100,
+        "readdir is not batching: {} calls for 1010 entries",
+        batches(&large)
+    );
+}

--- a/tests/syscalls.rs
+++ b/tests/syscalls.rs
@@ -158,6 +158,13 @@ fn a_listing_costs_one_stat_per_file_and_two_xattrs_per_dir() {
         ] {
             let expected: BTreeMap<&str, i64> = expected.iter().copied().collect();
             for (name, (delta, _)) in measured {
+                // readdir is exempt: it is batched, so its count grows by whole
+                // buffers as entries are added -- 2 calls for 12 entries, 3 for
+                // 112 -- which is a boundary, not a per-entry cost. That it stays
+                // batched at all is readdir_is_batched's assertion.
+                if name == "getdents64" {
+                    continue;
+                }
                 let want = expected.get(name.as_str()).copied().unwrap_or(0);
                 assert_eq!(
                     *delta,

--- a/tests/syscalls.rs
+++ b/tests/syscalls.rs
@@ -10,13 +10,9 @@
 //!
 //! Needs strace and permission to ptrace, so it skips when either is missing.
 //!
-//! What this does *not* cover: `ls()` polls for Ctrl-C once per entry, and crossterm
-//! only issues a syscall for that when its event source initialises, which needs a
-//! controlling terminal. Under a test runner /dev/tty fails to open with ENXIO, so
-//! the poll is free here and the interface may well pay one more syscall per entry
-//! than these numbers show. Measuring it needs a real terminal:
-//!
-//!     strace -f -c -o /tmp/tui.trace cephdu --tui <dir>   # then press q
+//! These numbers hold for the interface too: its cancellation check between
+//! entries is an atomic load, not a syscall, so a listing costs the same whether
+//! flat mode or a worker thread runs it.
 
 use std::collections::BTreeMap;
 use std::fs;


### PR DESCRIPTION
- **Non-blocking reads**: listings run on worker threads, so the directory on screen stays usable while a slow one loads. Cancellable with Ctrl-C.
- **Deferred metadata**: the owner and directory times are only read when shown or sorted on. The TUI fetches a missing column on demand.
- **Flat text mode**: `--flat` prints the listing as text with units, `--parseable` as raw tab-separated values for scripts. Parseable is implied when stdout is not a terminal.
- **Info panel**: `i` (or `-i`) toggles a panel with the non-recursive numbers — size and entries at this level against the recursive totals, plus recursive mean file size and entries per directory.
- **Sort flags**: `-n`/`-s`/`-c`/`-u`/`-t` choose the startup sort, `-r` reverses it, and `-d` groups directories first, all matching the TUI keys.
- **Exact mode**: `-e` (or `e`) shows sizes and counts in full instead of scaled to a unit.
- **Runtime default directory**: `CEPHDU_DEFAULT_DIR` in the environment overrides the compiled-in default, so one binary can start in the right place on each cluster via its modulefile.
- **Symlinks**: marked with `@` the way `ls -F` does, showing the link's own size.
- **UI polish**: colors inherit the terminal theme (`NO_COLOR` honored), horizontal scrolling for wide listings, and the sort in effect shown in the border.
- **Tests**: new end-to-end, syscall-count, and CephFS xattr suites; 119 tests total.